### PR TITLE
Guard against divide-by-zero and log(0) in KDE and likelihood code

### DIFF
--- a/src/non_local_detector/likelihoods/clusterless_kde.py
+++ b/src/non_local_detector/likelihoods/clusterless_kde.py
@@ -13,6 +13,7 @@ from non_local_detector.likelihoods.common import (
     gaussian_pdf,
     get_position_at_time,
     get_spike_time_bin_ind,
+    safe_log,
 )
 
 
@@ -81,7 +82,7 @@ def estimate_log_joint_mark_intensity(
     marginal_density = (
         spike_waveform_feature_distance.T @ position_distance / n_encoding_spikes
     )  # shape (n_decoding_spikes, n_position_bins)
-    return jnp.log(
+    return safe_log(
         mean_rate * jnp.where(occupancy > 0.0, marginal_density / occupancy, 0.0)
     )
 
@@ -551,7 +552,7 @@ def compute_local_log_likelihood(
         occupancy_at_spike_time = occupancy_model.predict(position_at_spike_time)
 
         log_likelihood += jax.ops.segment_sum(
-            jnp.log(
+            safe_log(
                 electrode_mean_rate
                 * jnp.where(
                     occupancy_at_spike_time > 0.0,

--- a/src/non_local_detector/likelihoods/common.py
+++ b/src/non_local_detector/likelihoods/common.py
@@ -143,7 +143,8 @@ def kde(
             jnp.expand_dims(dim_samples, axis=1),
             dim_std,
         )
-    return (weights @ distance) / jnp.sum(weights)
+    weight_sum = jnp.sum(weights)
+    return jnp.where(weight_sum > 0, (weights @ distance) / weight_sum, 0.0)
 
 
 def block_kde(

--- a/src/non_local_detector/likelihoods/sorted_spikes_kde.py
+++ b/src/non_local_detector/likelihoods/sorted_spikes_kde.py
@@ -188,7 +188,10 @@ def fit_sorted_spikes_kde_encoding_model(
         except np.exceptions.AxisError:
             pass
 
-        mean_rates.append(weights_at_spike_times.sum() / weights.sum())
+        weight_sum = weights.sum()
+        mean_rates.append(
+            weights_at_spike_times.sum() / weight_sum if weight_sum > 0 else 0.0
+        )
         neuron_marginal_model = KDEModel(std=position_std, block_size=block_size).fit(
             get_position_at_time(
                 position_time, position, neuron_spike_times, environment

--- a/src/non_local_detector/simulate/sorted_spikes_simulation.py
+++ b/src/non_local_detector/simulate/sorted_spikes_simulation.py
@@ -319,7 +319,9 @@ def get_firing_rate(
                 weights[is_spike.astype(bool) & not_nan_position], dtype=np.float32
             ),
         )
-        return np.spacing(1) + (mean_rate * marginal_density / occupancy)
+        return np.spacing(1) + (
+            mean_rate * np.where(occupancy > 0.0, marginal_density / occupancy, 0.0)
+        )
     else:
         return np.zeros_like(occupancy)
 

--- a/src/non_local_detector/tests/likelihoods/test_likelihood_edge_cases.py
+++ b/src/non_local_detector/tests/likelihoods/test_likelihood_edge_cases.py
@@ -252,10 +252,6 @@ def test_sorted_glm_zero_spikes_all_neurons():
     assert not jnp.any(jnp.isnan(ll))
 
 
-@pytest.mark.xfail(
-    reason="Clusterless KDE produces NaN when all electrodes have zero spikes",
-    strict=True,
-)
 def test_clusterless_kde_zero_spikes_all_electrodes():
     """Clusterless KDE should handle zero spikes without crash."""
     env = _make_env_1d()


### PR DESCRIPTION
## Summary
- Protect `kde()` weight-sum division with `jnp.where` to return zero density when all weights are zero
- Replace bare `jnp.log` with `safe_log` in `clusterless_kde.py` (both non-local and local likelihood paths) to avoid `log(0) = -inf`
- Guard `weights.sum()` division in `sorted_spikes_kde.py` encoding model fitting
- Protect `marginal_density / occupancy` in `sorted_spikes_simulation.py` for unvisited position bins
- Remove `xfail` on `test_clusterless_kde_zero_spikes_all_electrodes` which now passes

## Test plan
- [x] All 18 edge case tests pass (including previously-xfail zero-spikes test)
- [x] Full test suite: 333 passed, 3 xfailed, 2 skipped
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)