### PR TITLE
Guard n_encoding_spikes and kde weight_sum against zero division

### DIFF
--- a/src/non_local_detector/likelihoods/clusterless_kde.py
+++ b/src/non_local_detector/likelihoods/clusterless_kde.py
@@ -79,8 +79,12 @@ def estimate_log_joint_mark_intensity(
     )  # shape (n_encoding_spikes, n_decoding_spikes)
 
     n_encoding_spikes = encoding_spike_waveform_features.shape[0]
-    marginal_density = (
-        spike_waveform_feature_distance.T @ position_distance / n_encoding_spikes
+    # Double-where: substitute safe denominator, then select result
+    safe_n = jnp.where(n_encoding_spikes > 0, n_encoding_spikes, 1)
+    marginal_density = jnp.where(
+        n_encoding_spikes > 0,
+        spike_waveform_feature_distance.T @ position_distance / safe_n,
+        0.0,
     )  # shape (n_decoding_spikes, n_position_bins)
     return safe_log(
         mean_rate * jnp.where(occupancy > 0.0, marginal_density / occupancy, 0.0)

--- a/src/non_local_detector/likelihoods/clusterless_kde_log.py
+++ b/src/non_local_detector/likelihoods/clusterless_kde_log.py
@@ -593,8 +593,12 @@ def estimate_log_joint_mark_intensity(
             waveform_stds,
         )  # shape (n_encoding_spikes, n_decoding_spikes)
 
-        marginal_density = (
-            spike_waveform_feature_distance.T @ position_distance / n_encoding_spikes
+        # Double-where: substitute safe denominator, then select result
+        safe_n = jnp.where(n_encoding_spikes > 0, n_encoding_spikes, 1)
+        marginal_density = jnp.where(
+            n_encoding_spikes > 0,
+            spike_waveform_feature_distance.T @ position_distance / safe_n,
+            0.0,
         )  # shape (n_decoding_spikes, n_position_bins)
         # Use safe_log to avoid -inf from zero marginal_density or mean_rate
         return safe_log(
@@ -633,7 +637,9 @@ def estimate_log_joint_mark_intensity(
     n_dec = decoding_spike_waveform_features.shape[0]
 
     # Uniform weights: log(1/n) for each encoding spike
-    log_w = -jnp.log(float(n_encoding_spikes))  # n_encoding_spikes always > 0
+    # Use max(n, 1) to avoid log(0); when n=0 the result is unused
+    safe_n = jnp.where(n_encoding_spikes > 0, float(n_encoding_spikes), 1.0)
+    log_w = -jnp.log(safe_n)
 
     # If enc_tile_size specified, chunk over encoding spikes
     if enc_tile_size is not None and enc_tile_size < n_encoding_spikes:

--- a/src/non_local_detector/likelihoods/common.py
+++ b/src/non_local_detector/likelihoods/common.py
@@ -143,8 +143,11 @@ def kde(
             jnp.expand_dims(dim_samples, axis=1),
             dim_std,
         )
+    # Double-where pattern: substitute safe denominator, then select result.
+    # This avoids NaN in both forward pass and gradients.
     weight_sum = jnp.sum(weights)
-    return jnp.where(weight_sum > 0, (weights @ distance) / weight_sum, 0.0)
+    safe_weight_sum = jnp.where(weight_sum > 0, weight_sum, 1.0)
+    return jnp.where(weight_sum > 0, (weights @ distance) / safe_weight_sum, 0.0)
 
 
 def block_kde(


### PR DESCRIPTION
## Summary
- Guard `/ n_encoding_spikes` in `estimate_log_joint_mark_intensity` (both `clusterless_kde.py` and `clusterless_kde_log.py`) to avoid 0/0 = NaN when an electrode has no encoding spikes
- Guard `-jnp.log(n_encoding_spikes)` in the GEMM path to avoid log(0)
- Upgrade the PR #11 `kde()` weight_sum fix to use the JAX-idiomatic double-where pattern

## JAX double-where pattern
```python
# Step 1: make operand safe (replace 0 with any valid value)
safe_denom = jnp.where(denom > 0, denom, 1.0)
# Step 2: compute with safe operand, then select result
result = jnp.where(denom > 0, numerator / safe_denom, 0.0)
```
This avoids NaN in both forward pass and gradients, unlike `jnp.maximum` which poisons gradients, or single `jnp.where` which receives already-computed NaN as an argument.

## Test plan
- [x] All 53 KDE-related tests pass (edge cases, snapshots, parity, GEMM)
- [x] Zero-spikes edge case test passes without NaN
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)