### PR TITLE
Use JAX double-where pattern for all division and log guards

### DIFF
--- a/src/non_local_detector/core.py
+++ b/src/non_local_detector/core.py
@@ -98,7 +98,9 @@ def _safe_log(p: ArrayLike) -> jnp.ndarray:
     log_p : jnp.ndarray
         Log probabilities with -inf for zeros
     """
-    return jnp.where(p > 0, jnp.log(p), -jnp.inf)
+    # Double-where: substitute safe value into operand first
+    safe_p = jnp.where(p > 0, p, 1.0)
+    return jnp.where(p > 0, jnp.log(safe_p), -jnp.inf)
 
 
 def _divide_safe(numerator: ArrayLike, denominator: ArrayLike) -> jnp.ndarray:
@@ -117,8 +119,10 @@ def _divide_safe(numerator: ArrayLike, denominator: ArrayLike) -> jnp.ndarray:
     result : jnp.ndarray
         Element-wise division result with safe handling of zero denominators.
     """
-    # Use jnp.where for conditional division - XLA can optimize this well
-    return jnp.where(denominator != 0.0, numerator / denominator, 0.0)
+    # Double-where: substitute safe denominator first, then select result.
+    # This avoids NaN in both forward pass and gradients.
+    safe_denominator = jnp.where(denominator != 0.0, denominator, 1.0)
+    return jnp.where(denominator != 0.0, numerator / safe_denominator, 0.0)
 
 
 def filter(

--- a/src/non_local_detector/likelihoods/clusterless_gmm.py
+++ b/src/non_local_detector/likelihoods/clusterless_gmm.py
@@ -366,7 +366,12 @@ def fit_clusterless_gmm_encoding_model(
         # Expected-counts term at bins: mean_rate * (gpi / occupancy)
         gpi_density = _gmm_density(gpi_gmm, interior_place_bin_centers)
         summed_ground_process_intensity += jnp.clip(
-            mean_rate * jnp.where(occupancy > 0.0, gpi_density / occupancy, EPS),
+            mean_rate
+            * jnp.where(
+                occupancy > 0.0,
+                gpi_density / jnp.where(occupancy > 0.0, occupancy, 1.0),
+                EPS,
+            ),
             a_min=EPS,
             a_max=None,
         )

--- a/src/non_local_detector/likelihoods/clusterless_kde.py
+++ b/src/non_local_detector/likelihoods/clusterless_kde.py
@@ -83,7 +83,12 @@ def estimate_log_joint_mark_intensity(
         spike_waveform_feature_distance.T @ position_distance / n_encoding_spikes
     )  # shape (n_decoding_spikes, n_position_bins)
     return safe_log(
-        mean_rate * jnp.where(occupancy > 0.0, marginal_density / occupancy, 0.0)
+        mean_rate
+        * jnp.where(
+            occupancy > 0.0,
+            marginal_density / jnp.where(occupancy > 0.0, occupancy, 1.0),
+            0.0,
+        )
     )
 
 
@@ -252,7 +257,12 @@ def fit_clusterless_kde_encoding_model(
 
         gpi_density = gpi_model.predict(interior_place_bin_centers)
         summed_ground_process_intensity += jnp.clip(
-            mean_rates[-1] * jnp.where(occupancy > 0.0, gpi_density / occupancy, EPS),
+            mean_rates[-1]
+            * jnp.where(
+                occupancy > 0.0,
+                gpi_density / jnp.where(occupancy > 0.0, occupancy, 1.0),
+                EPS,
+            ),
             a_min=EPS,
             a_max=None,
         )
@@ -556,7 +566,8 @@ def compute_local_log_likelihood(
                 electrode_mean_rate
                 * jnp.where(
                     occupancy_at_spike_time > 0.0,
-                    marginal_density / occupancy_at_spike_time,
+                    marginal_density
+                    / jnp.where(occupancy_at_spike_time > 0.0, occupancy_at_spike_time, 1.0),
                     0.0,
                 )
             ),
@@ -567,7 +578,8 @@ def compute_local_log_likelihood(
 
         log_likelihood -= electrode_mean_rate * jnp.where(
             occupancy > 0.0,
-            electrode_gpi_model.predict(interpolated_position) / occupancy,
+            electrode_gpi_model.predict(interpolated_position)
+            / jnp.where(occupancy > 0.0, occupancy, 1.0),
             0.0,
         )
     return log_likelihood[:, jnp.newaxis]

--- a/src/non_local_detector/likelihoods/clusterless_kde.py
+++ b/src/non_local_detector/likelihoods/clusterless_kde.py
@@ -567,7 +567,9 @@ def compute_local_log_likelihood(
                 * jnp.where(
                     occupancy_at_spike_time > 0.0,
                     marginal_density
-                    / jnp.where(occupancy_at_spike_time > 0.0, occupancy_at_spike_time, 1.0),
+                    / jnp.where(
+                        occupancy_at_spike_time > 0.0, occupancy_at_spike_time, 1.0
+                    ),
                     0.0,
                 )
             ),

--- a/src/non_local_detector/likelihoods/clusterless_kde_log.py
+++ b/src/non_local_detector/likelihoods/clusterless_kde_log.py
@@ -598,7 +598,12 @@ def estimate_log_joint_mark_intensity(
         )  # shape (n_decoding_spikes, n_position_bins)
         # Use safe_log to avoid -inf from zero marginal_density or mean_rate
         return safe_log(
-            mean_rate * jnp.where(occupancy > 0.0, marginal_density / occupancy, EPS),
+            mean_rate
+            * jnp.where(
+                occupancy > 0.0,
+                marginal_density / jnp.where(occupancy > 0.0, occupancy, 1.0),
+                EPS,
+            ),
             eps=EPS,
         )
 
@@ -971,7 +976,12 @@ def fit_clusterless_kde_encoding_model(
 
         gpi_density = gpi_model.predict(interior_place_bin_centers)
         summed_ground_process_intensity += jnp.clip(
-            mean_rates[-1] * jnp.where(occupancy > 0.0, gpi_density / occupancy, EPS),
+            mean_rates[-1]
+            * jnp.where(
+                occupancy > 0.0,
+                gpi_density / jnp.where(occupancy > 0.0, occupancy, 1.0),
+                EPS,
+            ),
             a_min=EPS,
             a_max=None,
         )
@@ -1354,7 +1364,8 @@ def compute_local_log_likelihood(
 
         log_likelihood -= electrode_mean_rate * jnp.where(
             occupancy > 0.0,
-            electrode_gpi_model.predict(interpolated_position) / occupancy,
+            electrode_gpi_model.predict(interpolated_position)
+            / jnp.where(occupancy > 0.0, occupancy, 1.0),
             0.0,
         )
     return log_likelihood[:, jnp.newaxis]

--- a/src/non_local_detector/likelihoods/common.py
+++ b/src/non_local_detector/likelihoods/common.py
@@ -365,7 +365,10 @@ def safe_divide(numerator, denominator, eps=EPS, condition=None):
     if condition is None:
         condition = jnp.abs(denominator) < eps
 
-    return jnp.where(condition, eps, numerator / denominator)
+    # Double-where: substitute safe denominator first, then select result.
+    # This avoids NaN in both forward pass and gradients.
+    safe_denominator = jnp.where(condition, 1.0, denominator)
+    return jnp.where(condition, eps, numerator / safe_denominator)
 
 
 def safe_log(x, eps=EPS, condition=None):

--- a/src/non_local_detector/likelihoods/sorted_spikes_kde.py
+++ b/src/non_local_detector/likelihoods/sorted_spikes_kde.py
@@ -209,8 +209,7 @@ def fit_sorted_spikes_kde_encoding_model(
                     mean_rates[-1]
                     * jnp.where(
                         occupancy > 0.0,
-                        marginal_density
-                        / jnp.where(occupancy > 0.0, occupancy, 1.0),
+                        marginal_density / jnp.where(occupancy > 0.0, occupancy, 1.0),
                         EPS,
                     ),
                     min=EPS,

--- a/src/non_local_detector/likelihoods/sorted_spikes_kde.py
+++ b/src/non_local_detector/likelihoods/sorted_spikes_kde.py
@@ -207,7 +207,12 @@ def fit_sorted_spikes_kde_encoding_model(
             .set(
                 jnp.clip(
                     mean_rates[-1]
-                    * jnp.where(occupancy > 0.0, marginal_density / occupancy, EPS),
+                    * jnp.where(
+                        occupancy > 0.0,
+                        marginal_density
+                        / jnp.where(occupancy > 0.0, occupancy, 1.0),
+                        EPS,
+                    ),
                     min=EPS,
                     max=None,
                 )
@@ -321,7 +326,9 @@ def predict_sorted_spikes_kde_log_likelihood(
                 jnp.isnan(marginal_density), 0.0, marginal_density
             )
             local_rate = neuron_mean_rate * jnp.where(
-                occupancy > 0.0, marginal_density / occupancy, EPS
+                occupancy > 0.0,
+                marginal_density / jnp.where(occupancy > 0.0, occupancy, 1.0),
+                EPS,
             )
             local_rate = jnp.clip(local_rate, min=EPS, max=None)
             log_likelihood += (


### PR DESCRIPTION
## Summary
Systematic sweep replacing the single-where antipattern with the JAX-idiomatic double-where pattern across the entire codebase.

**The problem:** `jnp.where(cond, x / y, fallback)` computes `x / y` before `jnp.where` evaluates the condition, so 0/0 = NaN is already materialized. This also poisons gradients during autodiff.

**The fix:** Substitute a safe value into the operand first:
```python
safe_y = jnp.where(cond, y, 1.0)  # replace 0 with 1
jnp.where(cond, x / safe_y, fallback)  # division never sees 0
```

### Files changed (6)
- **core.py**: `_divide_safe()` and `_safe_log()` 
- **common.py**: `safe_divide()`
- **clusterless_kde.py**: 4 occupancy division guards
- **sorted_spikes_kde.py**: 2 occupancy division guards
- **clusterless_kde_log.py**: 3 occupancy division guards  
- **clusterless_gmm.py**: 1 occupancy division guard

## Test plan
- [x] 598 tests pass (full suite minus 1 pre-existing flaky hypothesis test)
- [x] All 23 property tests pass in isolation
- [x] All snapshot tests pass (no behavioral change)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)