### PR TITLE
Local state observation-channel cleanup

### DIFF
--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -2260,10 +2260,23 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         is_track_interior = self.is_track_interior_state_bins_
         cross_is_track_interior = np.ix_(is_track_interior, is_track_interior)
         state_ind = self.state_ind_[is_track_interior]
+
+        # Mirror _predict()'s multi-bin Local IC override so Viterbi and the
+        # forward-backward smoother see the same initial Local distribution.
+        position_time = (
+            log_likelihood_args[0] if len(log_likelihood_args) >= 2 else None
+        )
+        position = log_likelihood_args[1] if len(log_likelihood_args) >= 2 else None
+        override = self.compute_local_initial_conditions(position_time, position, time)
+        initial_conditions_full = (
+            override if override is not None else self.initial_conditions_
+        )
+        initial_distribution = initial_conditions_full[is_track_interior]
+
         if self.discrete_state_transitions_.ndim == 2:
             sequence_ind, _ = most_likely_sequence(
                 time=time,
-                initial_distribution=self.initial_conditions_[is_track_interior],
+                initial_distribution=initial_distribution,
                 transition_matrix=(
                     self.continuous_state_transitions_[cross_is_track_interior]
                     * self.discrete_state_transitions_[np.ix_(state_ind, state_ind)]
@@ -2278,7 +2291,7 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             sequence_ind, _ = most_likely_sequence_covariate_dependent(
                 time=time,
                 state_ind=state_ind,
-                initial_distribution=self.initial_conditions_[is_track_interior],
+                initial_distribution=initial_distribution,
                 discrete_transition_matrix=self.discrete_state_transitions_,
                 continuous_transition_matrix=self.continuous_state_transitions_[
                     cross_is_track_interior
@@ -3033,19 +3046,23 @@ class ClusterlessDetector(_DetectorBase):
         -----
         When ``local_position_std`` is set, the per-bin value returned
         for local-state entries is not a pure spike likelihood. It
-        combines the spatial spike likelihood with the Gaussian
-        observation density of the tracked position::
+        combines the spatial spike likelihood with an isotropic Gaussian
+        radial likelihood on graph/geodesic distance from the animal's
+        position to each bin (see :meth:`_compute_local_position_kernel`
+        for the exact formula and dimensionality dispatch)::
 
             log_likelihood[local, b, t] =
                 log P(spikes_t | bin b)               # spatial likelihood
-              + log N(d(b, animal_t); 0, σ²)          # tracked-position density
+              + log_kernel(b, animal_t)               # radial position likelihood
 
-        where ``d`` is shortest-path track-graph distance and
-        ``σ = local_position_std``. Mathematically, injecting the
-        tracked-position density into the likelihood is equivalent to
-        injecting it into the transition matrix — both multiply into
-        the HMM forward step — but avoids breaking the static-transition
-        assumption used by ``jax.lax.scan``.
+        where ``log_kernel`` uses ``σ = local_position_std`` and a
+        ``n_dims``-aware Gaussian normalizer (``n_dims = 1`` for
+        explicit linearized tracks, otherwise the position grid's
+        coordinate dimension). Mathematically, injecting this term into
+        the likelihood is equivalent to injecting it into the transition
+        matrix — both multiply into the HMM forward step — but avoids
+        breaking the static-transition assumption used by
+        ``jax.lax.scan``.
 
         The kernel is part of the likelihood model, not an ad-hoc
         post-processing step, so the posterior returned by ``predict()``
@@ -3055,7 +3072,7 @@ class ClusterlessDetector(_DetectorBase):
         differ); users reading the raw ``log_likelihood`` (via
         ``return_outputs='log_likelihood'``) should be aware that
         local-state entries are *not* pure ``log P(spikes | state, bin)``
-        — they include the Gaussian observation density.
+        — they include the radial position likelihood.
 
         Parameters
         ----------
@@ -3963,19 +3980,23 @@ class SortedSpikesDetector(_DetectorBase):
         -----
         When ``local_position_std`` is set, the per-bin value returned
         for local-state entries is not a pure spike likelihood. It
-        combines the spatial spike likelihood with the Gaussian
-        observation density of the tracked position::
+        combines the spatial spike likelihood with an isotropic Gaussian
+        radial likelihood on graph/geodesic distance from the animal's
+        position to each bin (see :meth:`_compute_local_position_kernel`
+        for the exact formula and dimensionality dispatch)::
 
             log_likelihood[local, b, t] =
                 log P(spikes_t | bin b)               # spatial likelihood
-              + log N(d(b, animal_t); 0, σ²)          # tracked-position density
+              + log_kernel(b, animal_t)               # radial position likelihood
 
-        where ``d`` is shortest-path track-graph distance and
-        ``σ = local_position_std``. Mathematically, injecting the
-        tracked-position density into the likelihood is equivalent to
-        injecting it into the transition matrix — both multiply into
-        the HMM forward step — but avoids breaking the static-transition
-        assumption used by ``jax.lax.scan``.
+        where ``log_kernel`` uses ``σ = local_position_std`` and a
+        ``n_dims``-aware Gaussian normalizer (``n_dims = 1`` for
+        explicit linearized tracks, otherwise the position grid's
+        coordinate dimension). Mathematically, injecting this term into
+        the likelihood is equivalent to injecting it into the transition
+        matrix — both multiply into the HMM forward step — but avoids
+        breaking the static-transition assumption used by
+        ``jax.lax.scan``.
 
         The kernel is part of the likelihood model, not an ad-hoc
         post-processing step, so the posterior returned by ``predict()``
@@ -3985,7 +4006,7 @@ class SortedSpikesDetector(_DetectorBase):
         differ); users reading the raw ``log_likelihood`` (via
         ``return_outputs='log_likelihood'``) should be aware that
         local-state entries are *not* pure ``log P(spikes | state, bin)``
-        — they include the Gaussian observation density.
+        — they include the radial position likelihood.
 
         Parameters
         ----------

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -5,7 +5,6 @@ import pickle
 import warnings
 from logging import getLogger
 
-import jax
 import jax.numpy as jnp
 import matplotlib
 import matplotlib.pyplot as plt
@@ -400,16 +399,18 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         self.no_spike_rate = no_spike_rate
 
         # Local position uncertainty parameter
-        if local_position_std is not None and local_position_std < 0:
+        if local_position_std is not None and local_position_std <= 0:
             raise ValidationError(
-                "local_position_std must be non-negative",
-                expected="float >= 0 or None",
+                "local_position_std must be strictly positive",
+                expected="float > 0 or None",
                 got=str(local_position_std),
                 hint=(
                     "Use None for legacy single-bin local (likelihood at "
-                    "the animal's exact interpolated position), 0.0 for "
-                    "multi-bin local with a delta kernel at the animal's "
-                    "bin, or > 0 for a Gaussian kernel."
+                    "the animal's exact interpolated position) or > 0 for "
+                    "a Gaussian kernel. Pass a small positive value (e.g. "
+                    "0.01) for effectively-delta behavior; the previous "
+                    "0.0 delta-kernel mode was removed because a Dirac "
+                    "density cannot be represented in log space."
                 ),
             )
         self.local_position_std = local_position_std
@@ -550,35 +551,32 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         position: jnp.ndarray,
         environment: "Environment",
     ) -> jnp.ndarray:
-        """Compute log position kernel for the local state.
+        """Compute log observation density for the multi-bin Local state.
 
-        Dispatches to one of two paths based on ``self.local_position_std``:
+        Returns the log of a proper Gaussian density over position:
 
-        - ``== 0``: delta kernel. ``log(n_bins)`` at the animal's bin,
-          ``-inf`` elsewhere (one-hot).
-        - ``> 0``: Gaussian kernel over shortest-path track-graph
-          distance (Euclidean fallback when no graph is fitted), then
-          normalized so ``exp(log_kernel)`` sums to ``n_interior_bins``
-          per time step. Unreachable bins on disconnected graph
-          components get zero probability naturally via ``exp(-inf)``.
+        ``log_kernel(t, b) = -0.5 * log(2π σ²) - 0.5 * d(b, animal_t)² / σ²``
 
-        Gap-bin positions (e.g. positions exactly on an arm-boundary
-        edge of a linearized track) are snapped to the nearest interior
-        bin by :meth:`Environment.get_bin_ind`, so the kernel is always
-        defined on a real interior bin.
+        where ``d`` is shortest-path track-graph distance (Euclidean
+        fallback when no graph is fitted) and ``σ = local_position_std``.
 
-        NaN animal positions (tracking dropouts) fall back to a uniform
-        kernel.
+        This is the observation channel of the Local state: it expresses
+        ``P(animal_t | Local, bin=b)`` — how likely the animal's tracked
+        position is given that the population is coding for bin ``b``,
+        with measurement noise ``σ``. It is *not* a normalized prior
+        over bins; integrating ``exp(log_kernel)`` over bin centers does
+        not yield a fixed value (scale depends on σ and bin spacing).
 
-        Both paths satisfy the invariant ``exp(log_kernel).sum(axis=1)
-        == n_bins``. Combined with the multi-bin local state's
-        ``1/n_bins`` uniform continuous initial conditions, this makes
-        the effective per-bin prior exactly ``exp(log_kernel)`` — so
-        the total Local state mass after the HMM forward step equals
-        ``p_local * P(spikes | animal_bin)`` in the delta limit.
+        Gap-bin positions (e.g. exactly on an arm-boundary edge) are
+        snapped to the nearest interior bin via
+        :meth:`Environment.get_bin_ind`, so distances are always defined
+        on real interior bins. Unreachable bins on disconnected graph
+        components get ``-inf`` (zero density) through the
+        ``exp(-0.5 * inf² / σ²)`` limit.
 
-        In the sharp-sigma limit, the Gaussian concentrates at the
-        animal's bin and matches the delta-kernel behavior numerically.
+        NaN animal positions (tracking dropouts) fall back to a flat
+        kernel (``log_kernel = 0``), giving the forward step at that
+        timestep no spatial information from this channel.
 
         Parameters
         ----------
@@ -594,17 +592,15 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         Returns
         -------
         log_kernel : jnp.ndarray, shape (n_time, n_interior_bins)
-            Log kernel. exp(log_kernel) sums to n_interior_bins per
-            time step (not 1).
+            Log Gaussian density of the tracked position given each
+            bin as the mean.
         """
         from non_local_detector.likelihoods.common import get_position_at_time
 
         assert self.local_position_std is not None  # narrowing for type checker
+        sigma = jnp.asarray(self.local_position_std, dtype=jnp.float32)
 
         animal_pos = get_position_at_time(position_time, position, time, environment)
-
-        n_bins = int(environment.is_track_interior_.sum())
-        log_n_bins = jnp.log(jnp.array(n_bins, dtype=jnp.float32))
 
         # Detect NaN positions (from gaps in position data)
         if animal_pos.ndim == 1:
@@ -612,55 +608,25 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         else:
             nan_mask = jnp.any(jnp.isnan(animal_pos), axis=-1)
 
-        # Delta kernel path: σ=0 concentrates the Local state on the
-        # single bin containing the animal. Emits log(n_bins) at that bin
-        # and -inf elsewhere, so after the multi-bin state's 1/n_bins
-        # uniform continuous IC, the total Local mass equals p_local ×
-        # P(spikes | animal_bin_center). Environment.get_bin_ind snaps
-        # gap-bin assignments to the nearest interior bin, so the only
-        # remaining case needing uniform fallback is a truly NaN animal
-        # position (tracking dropout).
-        if self.local_position_std == 0:
-            interior_bin_indices = np.where(environment.is_track_interior_.ravel())[0]
-            # Replace NaN animal positions with 0 before get_bin_ind (it
-            # has no NaN guard); nan_mask below masks those rows.
-            safe_animal_pos = np.nan_to_num(np.asarray(animal_pos), nan=0.0)
-            animal_bin_inds = environment.get_bin_ind(safe_animal_pos)
-            is_animal_bin = jnp.asarray(
-                animal_bin_inds[:, np.newaxis] == interior_bin_indices[np.newaxis, :]
-            )
-            log_kernel = jnp.where(is_animal_bin, log_n_bins, -jnp.inf)
-            log_kernel = jnp.where(nan_mask[:, jnp.newaxis], 0.0, log_kernel)
-            return log_kernel
-
-        # Gaussian kernel path (σ > 0). Uses topology-aware distance via
-        # Environment.get_distances_to_interior_bins(). After the
-        # get_bin_ind snap, the animal bin is always interior, so the
-        # distance-matrix row is always finite (no NaN rows). Unreachable
-        # bins on disconnected graph components stay as inf, which through
-        # exp(-0.5 * inf² / σ²) naturally yields zero probability there —
-        # the Gaussian concentrates on the reachable interior.
+        # Topology-aware distance via Environment.get_distances_to_interior_bins().
+        # After the get_bin_ind snap, the animal bin is always interior,
+        # so the distance-matrix row is always finite. Unreachable bins
+        # on disconnected components remain inf and become -inf log-density.
         dist = environment.get_distances_to_interior_bins(np.asarray(animal_pos))
         sq_dist = jnp.asarray(dist) ** 2
 
-        # Compute log-kernel with -inf at unreachable bins. jnp.where
-        # avoids inf/NaN propagation through the arithmetic ops below.
+        log_norm = -0.5 * jnp.log(2.0 * jnp.pi * sigma**2)
+
         reachable = jnp.isfinite(sq_dist)
         log_kernel = jnp.where(
-            reachable, -0.5 * sq_dist / (self.local_position_std**2), -jnp.inf
-        )
-        # Normalize to sum to n_bins (not 1) per time step. This compensates
-        # for the 1/n_bins uniform continuous IC of the multi-bin local state
-        # so the effective per-bin prior matches the kernel itself. Without
-        # this scaling, non-local states dominate by a factor of n_bins.
-        log_kernel = (
-            log_kernel
-            - jax.scipy.special.logsumexp(log_kernel, axis=1, keepdims=True)
-            + log_n_bins
+            reachable,
+            log_norm - 0.5 * sq_dist / (sigma**2),
+            -jnp.inf,
         )
 
-        # NaN animal positions (tracking dropout) fall back to a uniform
-        # kernel: each bin's exp value is 1, so log_kernel = 0 per bin.
+        # NaN animal positions (tracking dropout) fall back to a flat
+        # kernel (log_kernel = 0) so this channel contributes no spatial
+        # information at that timestep.
         log_kernel = jnp.where(nan_mask[:, jnp.newaxis], 0.0, log_kernel)
 
         return log_kernel
@@ -1052,6 +1018,119 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         self.n_state_bins_ = len(self.state_ind_)
         self.bin_sizes_ = np.array(bin_sizes)
         self.is_track_interior_state_bins_ = np.concatenate(is_track_interior)
+
+    def _predict_time_initial_conditions(
+        self,
+        time: np.ndarray,
+        log_likelihood_args: tuple,
+    ) -> np.ndarray:
+        """Return the initial conditions to use for a single ``_predict()`` call.
+
+        Falls back to ``self.initial_conditions_`` when the multi-bin Local
+        override doesn't apply (legacy single-bin Local, no position data,
+        or NaN initial position). Otherwise returns the full IC with the
+        Local rows replaced by a delta at the animal's first-bin.
+        """
+        position_time = log_likelihood_args[0] if len(log_likelihood_args) > 0 else None
+        position = log_likelihood_args[1] if len(log_likelihood_args) > 1 else None
+        override = self.compute_local_initial_conditions(position_time, position, time)
+        return override if override is not None else self.initial_conditions_
+
+    def compute_local_initial_conditions(
+        self,
+        position_time: np.ndarray | None,
+        position: np.ndarray | None,
+        time: np.ndarray,
+    ) -> np.ndarray | None:
+        """Predict-time initial conditions with the Local rows replaced by a
+        delta at the bin containing the animal's first interpolated position.
+
+        The stored ``self.initial_conditions_`` keeps a uniform Local block
+        because the IC depends on test-time data and cannot be fit-time data.
+        ``predict()`` and ``estimate_parameters()`` call this helper at the
+        start of each run and pass the result to ``_predict()`` as an
+        override; the stored array is never mutated.
+
+        Returns ``None`` (telling the caller to use the stored uniform IC)
+        when:
+
+        - ``self.local_position_std is None`` — legacy single-bin Local has
+          no per-bin distribution to override.
+        - ``position`` or ``position_time`` is None.
+        - The interpolated animal position at ``time[0]`` is NaN
+          (tracking dropout on the initial frame).
+
+        Parameters
+        ----------
+        position_time : np.ndarray, shape (n_time_position,) or None
+        position : np.ndarray, shape (n_time_position, n_position_dims) or None
+        time : np.ndarray, shape (n_time,)
+            Decoding time bins. The first entry determines the IC.
+
+        Returns
+        -------
+        override_initial_conditions : np.ndarray, shape (n_state_bins,) or None
+            Full IC array matching ``self.initial_conditions_``'s shape, with
+            Local rows replaced by a delta at the animal bin. ``None`` when
+            no override applies.
+        """
+        from dataclasses import replace as dataclass_replace
+
+        from non_local_detector.likelihoods.common import get_position_at_time
+
+        if (
+            self.local_position_std is None
+            or position is None
+            or position_time is None
+            or len(time) == 0
+        ):
+            return None
+
+        ic_parts = []
+        for obs, cont_ic in zip(
+            self.observation_models,
+            self.continuous_initial_conditions_types,
+            strict=False,
+        ):
+            if obs.is_local:
+                env = self.environments[self.environments.index(obs.environment_name)]
+                animal_pos_t0 = np.asarray(
+                    get_position_at_time(
+                        np.asarray(position_time),
+                        np.asarray(position),
+                        np.asarray(time[:1]),
+                        env,
+                    )
+                )
+                if np.any(np.isnan(animal_pos_t0)):
+                    return None
+
+                interior_bin_indices = np.where(env.is_track_interior_.ravel())[0]
+                n_interior = int(interior_bin_indices.size)
+                animal_pos_2d = (
+                    animal_pos_t0
+                    if animal_pos_t0.ndim == 2
+                    else animal_pos_t0[:, np.newaxis]
+                )
+                animal_bin = int(env.get_bin_ind(animal_pos_2d)[0])
+                interior_col = int(np.where(interior_bin_indices == animal_bin)[0][0])
+                delta_ic = np.zeros(n_interior, dtype=np.float32)
+                delta_ic[interior_col] = 1.0
+                ic_parts.append(delta_ic)
+            else:
+                # Multi-bin local case: ``initialize_initial_conditions`` builds
+                # spatial IC for non-local observation models via the stored
+                # ``cont_ic.make_initial_conditions(obs, ...)``. Reuse the
+                # same call so the non-Local rows stay identical.
+                effective_obs = obs
+                if obs.is_local and self.local_position_std is not None:
+                    effective_obs = dataclass_replace(obs, is_local=False)
+                ic_parts.append(
+                    cont_ic.make_initial_conditions(effective_obs, self.environments)
+                )
+
+        continuous_ic = np.concatenate(ic_parts).astype(np.float32)
+        return continuous_ic * self.discrete_initial_conditions[self.state_ind_]
 
     def initialize_initial_conditions(self) -> None:
         """Constructs the initial probability for the state and each spatial bin.
@@ -1618,6 +1697,15 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             self.discrete_state_transitions_. When None, falls back to the
             fitted attribute. By default None.
 
+        Notes
+        -----
+        When ``self.local_position_std`` is set and position data is
+        available in ``log_likelihood_args[:2]``, the multi-bin Local
+        state's initial conditions are replaced for this call with a
+        delta at the bin containing the animal's first interpolated
+        position (see :meth:`compute_local_initial_conditions`). The
+        stored ``self.initial_conditions_`` is not mutated.
+
         Returns
         -------
         acausal_posterior : np.ndarray, shape (n_time, n_state_bins)
@@ -1639,6 +1727,16 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         cross_is_track_interior = np.ix_(is_track_interior, is_track_interior)
         state_ind = self.state_ind_[is_track_interior]
 
+        # The stored ``self.initial_conditions_`` keeps a uniform Local block
+        # because it was fit before the test-time animal position was known.
+        # When predicting on test data with a multi-bin Local state, replace
+        # that block with a delta at the bin containing the animal's first
+        # interpolated position. The stored attribute is not mutated.
+        initial_conditions_full = self._predict_time_initial_conditions(
+            time, log_likelihood_args
+        )
+        initial_distribution = initial_conditions_full[is_track_interior]
+
         # Use provided transitions or fall back to fitted attribute
         discrete_transitions = (
             discrete_state_transitions
@@ -1650,7 +1748,7 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             return chunked_filter_smoother(
                 time=time,
                 state_ind=state_ind,
-                initial_distribution=self.initial_conditions_[is_track_interior],
+                initial_distribution=initial_distribution,
                 transition_matrix=(
                     self.continuous_state_transitions_[cross_is_track_interior]
                     * discrete_transitions[np.ix_(state_ind, state_ind)]
@@ -1666,7 +1764,7 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             return chunked_filter_smoother_covariate_dependent(
                 time=time,
                 state_ind=state_ind,
-                initial_distribution=self.initial_conditions_[is_track_interior],
+                initial_distribution=initial_distribution,
                 discrete_transition_matrix=discrete_transitions,
                 continuous_transition_matrix=self.continuous_state_transitions_[
                     cross_is_track_interior

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -558,9 +558,9 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             -0.5 * sq_dist / (self.non_local_penalty_std**2)
         )
 
-        # NaN animal positions produce zero penalty (no constraint during
-        # tracking dropouts) rather than a spurious penalty at a searchsorted-
-        # dependent bin.
+        # Rows whose interpolated animal position is NaN produce zero
+        # penalty (no constraint during tracking dropouts) rather than
+        # a spurious penalty at a searchsorted-dependent bin.
         return jnp.where(nan_mask[:, jnp.newaxis], 0.0, penalty)
 
     def _extract_animal_position(
@@ -660,9 +660,10 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         components get ``-inf`` (zero kernel) through the
         ``exp(-0.5 * inf² / σ²)`` limit.
 
-        NaN animal positions (tracking dropouts) fall back to a flat
-        kernel (``log_kernel = 0``), giving the forward step at that
-        timestep no spatial information from this channel.
+        Rows whose interpolated animal position is NaN (tracking
+        dropouts) fall back to a flat kernel (``log_kernel = 0`` over
+        all bins), giving the forward step no spatial information from
+        this channel for those rows.
 
         Parameters
         ----------
@@ -705,7 +706,8 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             raw - jax.scipy.special.logsumexp(raw, axis=1, keepdims=True) + log_n_bins
         )
 
-        # NaN animal positions (tracking dropout) → flat kernel at that step.
+        # Rows whose interpolated animal position is NaN fall back to a
+        # flat kernel (log_kernel = 0 over all bins).
         log_kernel = jnp.where(nan_mask[:, jnp.newaxis], 0.0, log_kernel)
         return log_kernel
 
@@ -725,8 +727,9 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         Local state's uniform ``1/n_bins`` continuous IC; without it,
         Non-Local dominates by a factor of ``n_bins``.
 
-        NaN animal positions (tracking dropouts) fall back to a flat
-        ``log_kernel = 0`` for that timestep.
+        Rows whose interpolated animal position is NaN (tracking
+        dropouts) fall back to a flat kernel (``log_kernel = 0`` over
+        all bins).
         """
         safe_animal_pos, nan_mask = self._extract_animal_position(
             time, position_time, position, environment

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -337,11 +337,17 @@ class _DetectorBase(BaseEstimator, abc.ABC):
               Local mass to the animal's snapped interior bin per
               timestep (one-hot kernel: ``log_kernel = 0`` at the bin
               and ``-inf`` elsewhere).
-            - ``> 0``: multi-bin Local with a Gaussian observation
-              density of standard deviation ``local_position_std`` (same
-              units as ``position``, typically centimeters) on the
-              shortest-path track-graph distance; models the
-              tracked-position measurement noise.
+            - ``> 0``: multi-bin Local with an *anchor-width* kernel
+              ``log_kernel = -0.5 * d² / σ²`` over shortest-path
+              graph/geodesic distance ``d`` (Euclidean fallback when no
+              distance matrix is fitted) and ``σ = local_position_std``.
+              Peak is 0 at the animal's bin and falls off with distance,
+              so ``σ`` controls the *spatial tolerance* of Local — how
+              far from the animal a Local bin can be while still being
+              credible — without re-weighting the Local-vs-non-Local
+              global evidence balance via a normalizer. Not a normalized
+              density; treat ``σ`` as an anchor-width hyperparameter,
+              not a calibrated measurement-noise scale.
         """
         # Validate all parameters early (Tier 1 & 2)
         self._validate_initial_conditions(
@@ -582,23 +588,6 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         sq_dist = jnp.nan_to_num(jnp.asarray(dist) ** 2, nan=jnp.inf, posinf=jnp.inf)
         return sq_dist, nan_mask
 
-    def _local_position_density_dim(self, environment: "Environment") -> int:
-        """Dimensionality used in the Local-state Gaussian radial likelihood.
-
-        Returns 1 for explicit linearized tracks (``track_graph is not None``)
-        and the position grid's coordinate dimension otherwise. See
-        :meth:`_compute_local_position_kernel` for the full kernel formula
-        and the modeling-assumption caveat.
-        """
-        if environment.track_graph is not None:
-            return 1
-        if environment.place_bin_centers_ is None:
-            raise ValueError(
-                "environment.place_bin_centers_ is None; "
-                "fit the environment before computing the Local kernel."
-            )
-        return int(environment.place_bin_centers_.shape[1])
-
     def _compute_local_position_kernel(
         self,
         time: jnp.ndarray,
@@ -606,47 +595,34 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         position: jnp.ndarray,
         environment: "Environment",
     ) -> jnp.ndarray:
-        """Compute log observation density for the multi-bin Local state.
+        """Spatial-anchor log-kernel for the multi-bin Local state.
 
-        For ``σ > 0`` returns an isotropic Gaussian *radial* likelihood:
+        For ``σ > 0`` returns the *unnormalized* anchor:
 
-        ``log_kernel(t, b) = -0.5 * n_dims * log(2π σ²) - 0.5 * d(b, animal_t)² / σ²``
+        ``log_kernel(t, b) = -0.5 * d(b, animal_t)² / σ²``
 
-        where ``σ = local_position_std`` and ``d`` and ``n_dims`` depend on
-        the environment (see :meth:`_local_position_density_dim`):
+        where ``d`` is shortest-path graph/geodesic distance (Euclidean
+        fallback when no distance matrix is fitted) and
+        ``σ = local_position_std``. The peak is always 0 at the animal's
+        bin and falls off with distance, so ``σ`` controls the *spatial
+        tolerance* of the Local state — how far from the animal a Local
+        bin can be while still being credible — without re-weighting the
+        Local-vs-non-Local global evidence balance via a normalizer.
 
-        - **Explicit linearized track** (``track_graph`` set): ``d`` is
-          shortest-path graph distance on a 1D manifold; ``n_dims = 1``.
-        - **2D / N-D occupancy grid** (``track_graphDD`` built by
-          ``Environment.fit_place_grid``, the default for fitted N-D
-          environments): ``d`` is graph/geodesic distance on the grid;
-          ``n_dims`` is the position grid's coordinate dimension.
-        - **Euclidean fallback** (no distance matrix): ``d`` is
-          Euclidean ``‖animal − bin_center‖``; same ``n_dims``.
-
-        This is a *radial* likelihood using graph/geodesic distance —
-        not an exact normalized heat kernel on an arbitrary graph with
-        holes/boundaries. The choice is a modeling assumption: σ has
-        units of distance, and the per-bin density treats the
-        animal-to-bin distance as the only quantity governing the
-        observation likelihood.
+        This is **not** a normalized density; integrating
+        ``exp(log_kernel)`` over bins varies with σ and bin spacing.
+        Treat ``local_position_std`` as an anchor-width hyperparameter,
+        not a calibrated measurement-noise scale.
 
         For ``σ == 0`` returns the delta-kernel limit: ``0`` at the
         animal's snapped interior bin, ``-inf`` elsewhere. Local mass
         commits exactly to that bin per timestep.
 
-        This is the observation channel of the Local state: it expresses
-        ``P(animal_t | Local, bin=b)`` — how likely the animal's tracked
-        position is given that the population is coding for bin ``b``,
-        with measurement noise ``σ``. It is *not* a normalized prior
-        over bins; integrating ``exp(log_kernel)`` over bin centers does
-        not yield a fixed value (scale depends on σ and bin spacing).
-
         Gap-bin positions (e.g. exactly on an arm-boundary edge) are
         snapped to the nearest interior bin via
         :meth:`Environment.get_bin_ind`, so distances are always defined
         on real interior bins. Unreachable bins on disconnected graph
-        components get ``-inf`` (zero density) through the
+        components get ``-inf`` (zero kernel) through the
         ``exp(-0.5 * inf² / σ²)`` limit.
 
         NaN animal positions (tracking dropouts) fall back to a flat
@@ -667,8 +643,7 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         Returns
         -------
         log_kernel : jnp.ndarray, shape (n_time, n_interior_bins)
-            Log Gaussian density of the tracked position given each
-            bin as the mean.
+            Spatial-anchor log-kernel; peak is 0 at the animal's bin.
         """
         assert self.local_position_std is not None  # narrowing for type checker
 
@@ -682,13 +657,10 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             time, position_time, position, environment
         )
 
-        n_dims = self._local_position_density_dim(environment)
-        log_norm = -0.5 * n_dims * jnp.log(2.0 * jnp.pi * sigma**2)
-
         reachable = jnp.isfinite(sq_dist)
         log_kernel = jnp.where(
             reachable,
-            log_norm - 0.5 * sq_dist / (sigma**2),
+            -0.5 * sq_dist / (sigma**2),
             -jnp.inf,
         )
         # NaN animal positions (tracking dropout) → flat kernel at that step.
@@ -1156,23 +1128,29 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         position: np.ndarray | None,
         time: np.ndarray,
     ) -> np.ndarray | None:
-        """Predict-time initial conditions with the Local block replaced by a
-        delta at the bin containing the animal's first interpolated position.
+        """Predict-time IC with the Local block replaced by a delta at the
+        bin containing the animal's first interpolated position.
 
-        Returns a full IC array matching the shape of
-        ``self.initial_conditions_``. The stored attribute is never mutated.
+        Starts from a copy of ``self.initial_conditions_`` and modifies
+        only the rows belonging to Local observation models, so any
+        EM-updated non-Local initial conditions (and the EM-updated
+        ``discrete_initial_conditions``, which are baked into the stored
+        full IC) are preserved verbatim. The Local block becomes a delta
+        scaled by ``discrete_initial_conditions[local_state_id]``. The
+        stored attribute is never mutated.
 
-        Returns ``None`` (signaling that the stored uniform Local IC should
-        be used unchanged) when:
+        Returns ``None`` (signaling that the stored uniform Local IC
+        should be used unchanged) when:
 
-        - ``self.local_position_std is None`` — legacy single-bin Local has
-          no per-bin distribution to override.
+        - ``self.local_position_std is None`` — legacy single-bin Local
+          has no per-bin distribution to override.
         - ``position`` or ``position_time`` is ``None`` — caller did not
           supply position data.
-        - The interpolated animal position at ``time[0]`` is NaN — tracking
-          dropout on the initial frame. A warning is logged in this case
-          because a frame-0 dropout usually indicates an upstream pipeline
-          issue.
+        - ``time`` is empty.
+        - The interpolated animal position at ``time[0]`` is NaN —
+          tracking dropout on the initial frame. A warning is logged
+          because a frame-0 dropout usually indicates an upstream
+          pipeline issue.
 
         Parameters
         ----------
@@ -1195,12 +1173,11 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         ):
             return None
 
-        nan_seen = False
-
-        def build_local_delta(
-            obs: "ObservationModel", env: "Environment"
-        ) -> np.ndarray:
-            nonlocal nan_seen
+        override = np.array(self.initial_conditions_, copy=True)
+        for state_id, obs in enumerate(self.observation_models):
+            if not obs.is_local:
+                continue
+            env = self.environments[self.environments.index(obs.environment_name)]
             animal_pos_t0 = np.asarray(
                 get_position_at_time(
                     np.asarray(position_time),
@@ -1209,15 +1186,13 @@ class _DetectorBase(BaseEstimator, abc.ABC):
                     env,
                 )
             )
-            n_local_bins = int(env.place_bin_centers_.shape[0])
             if np.any(np.isnan(animal_pos_t0)):
                 logger.warning(
                     "Multi-bin Local IC override skipped: first decoding "
-                    "frame's interpolated position is NaN. Stored uniform "
-                    "Local IC will be used."
+                    "frame's interpolated position is NaN. Stored Local "
+                    "IC will be used."
                 )
-                nan_seen = True
-                return np.zeros(n_local_bins, dtype=np.float32)
+                return None
 
             animal_pos_2d = (
                 animal_pos_t0
@@ -1225,19 +1200,13 @@ class _DetectorBase(BaseEstimator, abc.ABC):
                 else animal_pos_t0[:, np.newaxis]
             )
             animal_bin = int(env.get_bin_ind(animal_pos_2d)[0])
-            # Local block uses full place_bin_centers_ length to align with
-            # state_ind_ (interior + gap bins).
-            delta_ic = np.zeros(n_local_bins, dtype=np.float32)
-            delta_ic[animal_bin] = 1.0
-            return delta_ic
 
-        ic_parts = self._build_continuous_ic_parts(
-            local_block_builder=build_local_delta
-        )
-        if nan_seen:
-            return None
-        continuous_ic = np.concatenate(ic_parts).astype(np.float32)
-        return continuous_ic * self.discrete_initial_conditions[self.state_ind_]
+            block_mask = self.state_ind_ == state_id
+            block = np.zeros(int(block_mask.sum()), dtype=override.dtype)
+            block[animal_bin] = float(self.discrete_initial_conditions[state_id])
+            override[block_mask] = block
+
+        return override
 
     def _initial_distribution_for_decode(
         self,
@@ -3057,33 +3026,35 @@ class ClusterlessDetector(_DetectorBase):
         -----
         When ``local_position_std`` is set, the per-bin value returned
         for local-state entries is not a pure spike likelihood. It
-        combines the spatial spike likelihood with an isotropic Gaussian
-        radial likelihood on graph/geodesic distance from the animal's
-        position to each bin (see :meth:`_compute_local_position_kernel`
-        for the exact formula and dimensionality dispatch)::
+        combines the spatial spike likelihood with a spatial-anchor
+        log-kernel on graph/geodesic distance from the animal's position
+        to each bin (see :meth:`_compute_local_position_kernel` for the
+        exact formula)::
 
             log_likelihood[local, b, t] =
                 log P(spikes_t | bin b)               # spatial likelihood
-              + log_kernel(b, animal_t)               # radial position likelihood
+              + log_kernel(b, animal_t)               # anchor: peak 0 at animal_t
 
-        where ``log_kernel`` uses ``σ = local_position_std`` and a
-        ``n_dims``-aware Gaussian normalizer (``n_dims = 1`` for
-        explicit linearized tracks, otherwise the position grid's
-        coordinate dimension). Mathematically, injecting this term into
-        the likelihood is equivalent to injecting it into the transition
-        matrix — both multiply into the HMM forward step — but avoids
-        breaking the static-transition assumption used by
+        where ``log_kernel = -0.5 * d² / σ²`` with ``σ =
+        local_position_std``. The kernel is *not* a normalized density
+        (no ``log(2π σ²)`` term); ``σ`` controls Local's spatial
+        tolerance — how far from the animal a Local bin remains
+        credible — without re-weighting Local-vs-non-Local global
+        evidence via a normalizer. Mathematically, injecting this term
+        into the likelihood is equivalent to injecting it into the
+        transition matrix — both multiply into the HMM forward step —
+        but avoids breaking the static-transition assumption used by
         ``jax.lax.scan``.
 
-        The kernel is part of the likelihood model, not an ad-hoc
-        post-processing step, so the posterior returned by ``predict()``
-        is a valid probability distribution under the modified
-        generative model. Users comparing ``local_position_std=None`` to
-        a finite value will see different posteriors (the models
-        differ); users reading the raw ``log_likelihood`` (via
+        The kernel is part of the model, not an ad-hoc post-processing
+        step, so the posterior returned by ``predict()`` is a valid
+        probability distribution under the modified generative model.
+        Users comparing ``local_position_std=None`` to a finite value
+        will see different posteriors (the models differ); users reading
+        the raw ``log_likelihood`` (via
         ``return_outputs='log_likelihood'``) should be aware that
         local-state entries are *not* pure ``log P(spikes | state, bin)``
-        — they include the radial position likelihood.
+        — they include the anchor kernel.
 
         Parameters
         ----------
@@ -3991,33 +3962,35 @@ class SortedSpikesDetector(_DetectorBase):
         -----
         When ``local_position_std`` is set, the per-bin value returned
         for local-state entries is not a pure spike likelihood. It
-        combines the spatial spike likelihood with an isotropic Gaussian
-        radial likelihood on graph/geodesic distance from the animal's
-        position to each bin (see :meth:`_compute_local_position_kernel`
-        for the exact formula and dimensionality dispatch)::
+        combines the spatial spike likelihood with a spatial-anchor
+        log-kernel on graph/geodesic distance from the animal's position
+        to each bin (see :meth:`_compute_local_position_kernel` for the
+        exact formula)::
 
             log_likelihood[local, b, t] =
                 log P(spikes_t | bin b)               # spatial likelihood
-              + log_kernel(b, animal_t)               # radial position likelihood
+              + log_kernel(b, animal_t)               # anchor: peak 0 at animal_t
 
-        where ``log_kernel`` uses ``σ = local_position_std`` and a
-        ``n_dims``-aware Gaussian normalizer (``n_dims = 1`` for
-        explicit linearized tracks, otherwise the position grid's
-        coordinate dimension). Mathematically, injecting this term into
-        the likelihood is equivalent to injecting it into the transition
-        matrix — both multiply into the HMM forward step — but avoids
-        breaking the static-transition assumption used by
+        where ``log_kernel = -0.5 * d² / σ²`` with ``σ =
+        local_position_std``. The kernel is *not* a normalized density
+        (no ``log(2π σ²)`` term); ``σ`` controls Local's spatial
+        tolerance — how far from the animal a Local bin remains
+        credible — without re-weighting Local-vs-non-Local global
+        evidence via a normalizer. Mathematically, injecting this term
+        into the likelihood is equivalent to injecting it into the
+        transition matrix — both multiply into the HMM forward step —
+        but avoids breaking the static-transition assumption used by
         ``jax.lax.scan``.
 
-        The kernel is part of the likelihood model, not an ad-hoc
-        post-processing step, so the posterior returned by ``predict()``
-        is a valid probability distribution under the modified
-        generative model. Users comparing ``local_position_std=None`` to
-        a finite value will see different posteriors (the models
-        differ); users reading the raw ``log_likelihood`` (via
+        The kernel is part of the model, not an ad-hoc post-processing
+        step, so the posterior returned by ``predict()`` is a valid
+        probability distribution under the modified generative model.
+        Users comparing ``local_position_std=None`` to a finite value
+        will see different posteriors (the models differ); users reading
+        the raw ``log_likelihood`` (via
         ``return_outputs='log_likelihood'``) should be aware that
         local-state entries are *not* pure ``log P(spikes | state, bin)``
-        — they include the radial position likelihood.
+        — they include the anchor kernel.
 
         Parameters
         ----------

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -3,6 +3,7 @@ import copy
 import inspect
 import pickle
 import warnings
+from collections.abc import Callable
 from logging import getLogger
 
 import jax.numpy as jnp
@@ -396,22 +397,21 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         self.sampling_frequency = sampling_frequency
         self.no_spike_rate = no_spike_rate
 
-        # Local position uncertainty parameter
-        if local_position_std is not None and not (
-            np.isfinite(local_position_std) and local_position_std > 0
-        ):
-            raise ValidationError(
-                "local_position_std must be a finite, strictly positive float",
-                expected="float > 0 or None",
-                got=str(local_position_std),
-                hint=(
-                    "Use None for legacy single-bin local (likelihood at "
-                    "the animal's exact interpolated position) or a finite "
-                    "positive value for a Gaussian observation density. "
-                    "Pass a small positive value (e.g. 0.01) for "
-                    "effectively-delta behavior."
-                ),
+        if local_position_std is not None:
+            val.ensure_positive_scalar(
+                local_position_std, "local_position_std", minimum=0.0, strict=True
             )
+            if not np.isfinite(local_position_std):
+                raise ValidationError(
+                    "local_position_std must be finite",
+                    expected="finite float > 0 or None",
+                    got=str(local_position_std),
+                    hint=(
+                        "Use None for legacy single-bin local or a finite "
+                        "positive value (e.g. 0.01 for near-delta) for a "
+                        "Gaussian observation density."
+                    ),
+                )
         self.local_position_std = local_position_std
 
     def _validate_position_dimensionality(
@@ -508,31 +508,9 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         penalty : jnp.ndarray, shape (n_time, n_interior_bins)
             Non-positive penalty values (to be added to log-likelihood).
         """
-        from non_local_detector.likelihoods.common import get_position_at_time
-
-        animal_pos = get_position_at_time(position_time, position, time, environment)
-        animal_pos_arr = np.asarray(animal_pos)
-
-        # Detect NaN animal positions (tracking dropouts). get_bin_ind does
-        # not guard against NaN — np.searchsorted(nan) returns an arbitrary
-        # valid bin index, so a NaN position would produce a finite distance
-        # and thus a spurious penalty at an unrelated bin. Mask those rows
-        # to zero after computing the penalty.
-        if animal_pos_arr.ndim == 1:
-            nan_mask = jnp.isnan(jnp.asarray(animal_pos_arr))
-        else:
-            nan_mask = jnp.any(jnp.isnan(jnp.asarray(animal_pos_arr)), axis=-1)
-
-        # Topology-aware distance (graph shortest path when available).
-        # Replace NaN animal positions with 0 before the lookup to avoid
-        # undefined searchsorted behavior; nan_mask masks those rows below.
-        safe_animal_pos = np.nan_to_num(animal_pos_arr, nan=0.0)
-        dist = environment.get_distances_to_interior_bins(safe_animal_pos)
-
-        # NaN (off-track bin-to-bin lookups) and inf (unreachable bins) →
-        # treat as infinitely far so the penalty evaluates to zero at those
-        # cells, avoiding NaN propagation into the log-likelihood.
-        sq_dist = jnp.nan_to_num(jnp.asarray(dist) ** 2, nan=jnp.inf, posinf=jnp.inf)
+        sq_dist, nan_mask = self._animal_sq_distance_to_interior_bins(
+            time, position_time, position, environment
+        )
 
         penalty = -self.non_local_position_penalty * jnp.exp(
             -0.5 * sq_dist / (self.non_local_penalty_std**2)
@@ -542,6 +520,40 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         # tracking dropouts) rather than a spurious penalty at a searchsorted-
         # dependent bin.
         return jnp.where(nan_mask[:, jnp.newaxis], 0.0, penalty)
+
+    def _animal_sq_distance_to_interior_bins(
+        self,
+        time: jnp.ndarray,
+        position_time: jnp.ndarray,
+        position: jnp.ndarray,
+        environment: "Environment",
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        """NaN-safe squared track-graph distances and a NaN-row mask.
+
+        ``get_bin_ind`` goes through ``np.searchsorted``, which is undefined
+        on NaN. Replace NaN coords with 0.0 before the distance lookup, then
+        let callers use the returned mask to zero out NaN-row outputs.
+        Non-finite distances (NaN bin-to-bin lookups, inf unreachable bins)
+        are mapped to ``inf`` so ``exp(-0.5 * inf / σ²) == 0`` cleanly.
+
+        Returns
+        -------
+        sq_dist : jnp.ndarray, shape (n_time, n_interior_bins)
+        nan_mask : jnp.ndarray, shape (n_time,)  bool
+        """
+        from non_local_detector.likelihoods.common import get_position_at_time
+
+        animal_pos = get_position_at_time(position_time, position, time, environment)
+        animal_pos_arr = np.asarray(animal_pos)
+        if animal_pos_arr.ndim == 1:
+            nan_mask = jnp.isnan(jnp.asarray(animal_pos_arr))
+        else:
+            nan_mask = jnp.any(jnp.isnan(jnp.asarray(animal_pos_arr)), axis=-1)
+
+        safe_animal_pos = np.nan_to_num(animal_pos_arr, nan=0.0)
+        dist = environment.get_distances_to_interior_bins(safe_animal_pos)
+        sq_dist = jnp.nan_to_num(jnp.asarray(dist) ** 2, nan=jnp.inf, posinf=jnp.inf)
+        return sq_dist, nan_mask
 
     def _compute_local_position_kernel(
         self,
@@ -594,42 +606,22 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             Log Gaussian density of the tracked position given each
             bin as the mean.
         """
-        from non_local_detector.likelihoods.common import get_position_at_time
-
         assert self.local_position_std is not None  # narrowing for type checker
         sigma = jnp.asarray(self.local_position_std, dtype=jnp.float32)
 
-        animal_pos = get_position_at_time(position_time, position, time, environment)
-
-        # Detect NaN positions (from gaps in position data)
-        if animal_pos.ndim == 1:
-            nan_mask = jnp.isnan(animal_pos)
-        else:
-            nan_mask = jnp.any(jnp.isnan(animal_pos), axis=-1)
-
-        # NaN-safe input to the topology-aware distance lookup. The post-hoc
-        # ``nan_mask`` overwrite below makes the final result correct, but
-        # the distance helper goes through ``get_bin_ind`` -> ``np.searchsorted``
-        # which is undefined on NaN. Replace NaN coords with 0.0 first to
-        # mirror ``_compute_non_local_position_penalty`` (line ~528).
-        safe_animal_pos = np.nan_to_num(np.asarray(animal_pos), nan=0.0)
-        dist = environment.get_distances_to_interior_bins(safe_animal_pos)
-        sq_dist = jnp.asarray(dist) ** 2
+        sq_dist, nan_mask = self._animal_sq_distance_to_interior_bins(
+            time, position_time, position, environment
+        )
 
         log_norm = -0.5 * jnp.log(2.0 * jnp.pi * sigma**2)
-
         reachable = jnp.isfinite(sq_dist)
         log_kernel = jnp.where(
             reachable,
             log_norm - 0.5 * sq_dist / (sigma**2),
             -jnp.inf,
         )
-
-        # NaN animal positions (tracking dropout) fall back to a flat
-        # kernel (log_kernel = 0) so this channel contributes no spatial
-        # information at that timestep.
+        # NaN animal positions (tracking dropout) → flat kernel at that step.
         log_kernel = jnp.where(nan_mask[:, jnp.newaxis], 0.0, log_kernel)
-
         return log_kernel
 
     def _validate_initial_conditions(
@@ -1020,35 +1012,47 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         self.bin_sizes_ = np.array(bin_sizes)
         self.is_track_interior_state_bins_ = np.concatenate(is_track_interior)
 
-    def _predict_time_initial_conditions(
+    def _build_continuous_ic_parts(
         self,
-        time: np.ndarray,
-        log_likelihood_args: tuple,
-    ) -> np.ndarray:
-        """Return the initial conditions to use for a single ``_predict()`` call.
+        local_block_builder: "Callable[[ObservationModel, Environment], np.ndarray] | None" = None,
+    ) -> list[np.ndarray]:
+        """Build per-observation-model continuous-IC blocks.
 
-        Falls back to ``self.initial_conditions_`` when the multi-bin Local
-        override doesn't apply (legacy single-bin Local, or no position data
-        is available — see :meth:`compute_local_initial_conditions`).
+        For each observation model, returns its block of the continuous IC:
+        either via ``local_block_builder`` for multi-bin Local states (when
+        ``local_position_std`` is set and a builder is supplied), or via the
+        configured ``cont_ic.make_initial_conditions`` for everything else.
+        Multi-bin Local without a builder uses ``UniformInitialConditions``
+        on interior bins (the fit-time default).
         """
-        if self.local_position_std is None:
-            return self.initial_conditions_
+        from dataclasses import replace
 
-        if len(log_likelihood_args) < 2:
-            logger.warning(
-                "_predict() called with local_position_std=%g but "
-                "log_likelihood_args has only %d entries (expected position_time "
-                "at index 0 and position at index 1). Falling back to the stored "
-                "uniform Local initial conditions.",
-                self.local_position_std,
-                len(log_likelihood_args),
+        ic_parts = []
+        for obs, cont_ic in zip(
+            self.observation_models,
+            self.continuous_initial_conditions_types,
+            strict=False,
+        ):
+            if (
+                obs.is_local
+                and self.local_position_std is not None
+                and local_block_builder is not None
+            ):
+                env = self.environments[self.environments.index(obs.environment_name)]
+                ic_parts.append(local_block_builder(obs, env))
+                continue
+
+            # Multi-bin Local without a builder needs the full spatial IC
+            # (uniform interior); other states use the configured IC.
+            effective_obs = (
+                replace(obs, is_local=False)
+                if obs.is_local and self.local_position_std is not None
+                else obs
             )
-            return self.initial_conditions_
-
-        override = self.compute_local_initial_conditions(
-            log_likelihood_args[0], log_likelihood_args[1], time
-        )
-        return override if override is not None else self.initial_conditions_
+            ic_parts.append(
+                cont_ic.make_initial_conditions(effective_obs, self.environments)
+            )
+        return ic_parts
 
     def compute_local_initial_conditions(
         self,
@@ -1095,66 +1099,47 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         ):
             return None
 
-        ic_parts = []
-        for obs, cont_ic in zip(
-            self.observation_models,
-            self.continuous_initial_conditions_types,
-            strict=False,
-        ):
-            if obs.is_local:
-                env = self.environments[self.environments.index(obs.environment_name)]
-                animal_pos_t0 = np.asarray(
-                    get_position_at_time(
-                        np.asarray(position_time),
-                        np.asarray(position),
-                        np.asarray(time[:1]),
-                        env,
-                    )
-                )
-                if np.any(np.isnan(animal_pos_t0)):
-                    logger.warning(
-                        "Multi-bin Local IC override skipped: first decoding "
-                        "frame's interpolated position is NaN. The stored "
-                        "uniform Local initial conditions will be used. This "
-                        "usually indicates a tracking dropout at the start of "
-                        "the recording or a time grid that begins before "
-                        "position data."
-                    )
-                    return None
+        nan_seen = False
 
-                # Build the Local block at the FULL bin granularity (including
-                # gap bins for linearized multi-arm tracks). state_ind_ and the
-                # non-Local IC parts use the full place_bin_centers_ length, so
-                # the Local block must too — building at n_interior here would
-                # broadcast-fail at the discrete_initial_conditions[state_ind_]
-                # multiplication for any environment with edge_spacing > 0.
-                n_local_bins = int(env.place_bin_centers_.shape[0])
-                animal_pos_2d = (
-                    animal_pos_t0
-                    if animal_pos_t0.ndim == 2
-                    else animal_pos_t0[:, np.newaxis]
+        def build_local_delta(
+            obs: "ObservationModel", env: "Environment"
+        ) -> np.ndarray:
+            nonlocal nan_seen
+            animal_pos_t0 = np.asarray(
+                get_position_at_time(
+                    np.asarray(position_time),
+                    np.asarray(position),
+                    np.asarray(time[:1]),
+                    env,
                 )
-                animal_bin = int(env.get_bin_ind(animal_pos_2d)[0])
-                if not bool(env.is_track_interior_.ravel()[animal_bin]):
-                    raise ValidationError(
-                        "Multi-bin Local IC override could not place a delta: "
-                        "Environment.get_bin_ind returned a non-interior bin",
-                        expected="interior bin index",
-                        got=f"animal_bin={animal_bin} (gap bin)",
-                        hint=(
-                            "This usually means the animal's first-frame "
-                            "position is in a gap region where the snap "
-                            "could not find a nearby interior bin. Check "
-                            "your environment's edge_spacing and the "
-                            "first-frame position."
-                        ),
-                    )
-                delta_ic = np.zeros(n_local_bins, dtype=np.float32)
-                delta_ic[animal_bin] = 1.0
-                ic_parts.append(delta_ic)
-            else:
-                ic_parts.append(cont_ic.make_initial_conditions(obs, self.environments))
+            )
+            n_local_bins = int(env.place_bin_centers_.shape[0])
+            if np.any(np.isnan(animal_pos_t0)):
+                logger.warning(
+                    "Multi-bin Local IC override skipped: first decoding "
+                    "frame's interpolated position is NaN. Stored uniform "
+                    "Local IC will be used."
+                )
+                nan_seen = True
+                return np.zeros(n_local_bins, dtype=np.float32)
 
+            animal_pos_2d = (
+                animal_pos_t0
+                if animal_pos_t0.ndim == 2
+                else animal_pos_t0[:, np.newaxis]
+            )
+            animal_bin = int(env.get_bin_ind(animal_pos_2d)[0])
+            # Local block uses full place_bin_centers_ length to align with
+            # state_ind_ (interior + gap bins).
+            delta_ic = np.zeros(n_local_bins, dtype=np.float32)
+            delta_ic[animal_bin] = 1.0
+            return delta_ic
+
+        ic_parts = self._build_continuous_ic_parts(
+            local_block_builder=build_local_delta
+        )
+        if nan_seen:
+            return None
         continuous_ic = np.concatenate(ic_parts).astype(np.float32)
         return continuous_ic * self.discrete_initial_conditions[self.state_ind_]
 
@@ -1169,21 +1154,7 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             Overall initial probability distribution across all state bins.
         """
         logger.info("Fitting initial conditions...")
-        from dataclasses import replace
-
-        ic_parts = []
-        for obs, cont_ic in zip(
-            self.observation_models,
-            self.continuous_initial_conditions_types,
-            strict=False,
-        ):
-            # Multi-bin local uses full spatial initial conditions
-            effective_obs = obs
-            if obs.is_local and self.local_position_std is not None:
-                effective_obs = replace(obs, is_local=False)
-            ic_parts.append(
-                cont_ic.make_initial_conditions(effective_obs, self.environments)
-            )
+        ic_parts = self._build_continuous_ic_parts()
         self.continuous_initial_conditions_ = np.concatenate(ic_parts)
         self.initial_conditions_ = (
             self.continuous_initial_conditions_
@@ -1753,13 +1724,17 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         cross_is_track_interior = np.ix_(is_track_interior, is_track_interior)
         state_ind = self.state_ind_[is_track_interior]
 
-        # The stored ``self.initial_conditions_`` keeps a uniform Local block
-        # because it was fit before the test-time animal position was known.
-        # When predicting on test data with a multi-bin Local state, replace
-        # that block with a delta at the bin containing the animal's first
-        # interpolated position. The stored attribute is not mutated.
-        initial_conditions_full = self._predict_time_initial_conditions(
-            time, log_likelihood_args
+        # When the multi-bin Local state is configured and position data is
+        # available in ``log_likelihood_args[:2]``, replace the Local rows
+        # of the IC with a delta at the animal's first-frame bin. Stored
+        # ``self.initial_conditions_`` is not mutated.
+        position_time = (
+            log_likelihood_args[0] if len(log_likelihood_args) >= 2 else None
+        )
+        position = log_likelihood_args[1] if len(log_likelihood_args) >= 2 else None
+        override = self.compute_local_initial_conditions(position_time, position, time)
+        initial_conditions_full = (
+            override if override is not None else self.initial_conditions_
         )
         initial_distribution = initial_conditions_full[is_track_interior]
 

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -422,21 +422,26 @@ class _DetectorBase(BaseEstimator, abc.ABC):
                         "value for the spatial-anchor kernel width."
                     ),
                 )
-            # Reject positive values that underflow to 0 in float32 — the
-            # kernel evaluates -0.5 * d^2 / sigma^2 at float32 precision, so
-            # sigma <= ~1.18e-38 silently becomes a divide-by-zero. Callers
-            # who want a delta should pass 0.0 explicitly.
-            if (
-                local_position_std > 0
-                and float(np.asarray(local_position_std, dtype=np.float32)) == 0.0
-            ):
+            # Reject positive values whose float32 *square* would underflow
+            # into 0 or the subnormal range. The kernel evaluates
+            # -0.5 * d^2 / sigma^2 at float32 precision, and JAX runtimes
+            # commonly flush subnormals to zero (FTZ), so any sigma below
+            # sqrt(float32 tiny) ≈ 1.085e-19 silently produces a divide-by-
+            # zero. Callers who want a delta should pass 0.0 explicitly.
+            f32_min_sigma = float(np.sqrt(np.finfo(np.float32).tiny))
+            if 0 < float(local_position_std) < f32_min_sigma:
                 raise ValidationError(
-                    "local_position_std underflows to 0 in float32",
-                    expected="0.0, or a positive value representable in float32",
+                    "local_position_std**2 underflows to 0 in float32",
+                    expected=(
+                        "0.0, or a positive value with a representable "
+                        "float32 square (>= sqrt(float32 tiny) "
+                        f"~{f32_min_sigma:.3e})"
+                    ),
                     got=str(local_position_std),
                     hint=(
-                        "Pass 0.0 explicitly for the delta kernel, or use a "
-                        "value larger than the float32 minimum (~1.18e-38)."
+                        "Pass 0.0 explicitly for the delta kernel, or use "
+                        f"a value >= {f32_min_sigma:.3e} so sigma**2 is "
+                        "representable as a normal float32."
                     ),
                 )
         self.local_position_std = local_position_std

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -334,21 +334,30 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             - ``None`` (default): legacy behavior. Local state occupies a
               single bin; the likelihood is evaluated at the animal's
               exact interpolated position (continuous).
-            - ``0.0``: multi-bin Local with a delta kernel that commits
+            - ``0.0``: multi-bin Local with a delta kernel committing
               Local mass to the animal's snapped interior bin per
-              timestep (one-hot kernel: ``log_kernel = 0`` at the bin
-              and ``-inf`` elsewhere).
+              timestep. ``log_kernel = log(n_bins)`` at the bin and
+              ``-inf`` elsewhere, so ``exp(log_kernel)`` sums to
+              ``n_bins`` per timestep — see ``> 0`` for the rationale.
             - ``> 0``: multi-bin Local with an *anchor-width* kernel
-              ``log_kernel = -0.5 * d² / σ²`` over shortest-path
+              ``raw = -0.5 * d² / σ²`` over shortest-path
               graph/geodesic distance ``d`` (Euclidean fallback when no
-              distance matrix is fitted) and ``σ = local_position_std``.
-              Peak is 0 at the animal's bin and falls off with distance,
-              so ``σ`` controls the *spatial tolerance* of Local — how
-              far from the animal a Local bin can be while still being
-              credible — without re-weighting the Local-vs-non-Local
-              global evidence balance via a normalizer. Not a normalized
-              density; treat ``σ`` as an anchor-width hyperparameter,
-              not a calibrated measurement-noise scale.
+              distance matrix is fitted) and ``σ = local_position_std``,
+              rescaled per timestep so ``exp(log_kernel).sum(axis=1) ==
+              n_bins``. The rescaling is HMM-state mass calibration: it
+              cancels the multi-bin Local state's uniform ``1/n_bins``
+              continuous-IC factor, which would otherwise let Non-Local
+              dominate by a factor of ``n_bins`` regardless of σ. ``σ``
+              controls the *spatial tolerance* of Local — how far from
+              the animal a Local bin can be while still credible — and
+              is an anchor-width hyperparameter, not a calibrated
+              measurement-noise standard deviation. Note: at ``t=0``
+              the predict-time IC override already concentrates Local
+              mass at the animal's bin, so the kernel's
+              ``+ log(n_bins)`` compensation overlaps with the override
+              for that single frame; for typical decoding windows this
+              is negligible, but tight marginal-likelihood comparisons
+              of very short sequences should be aware of it.
         """
         # Validate all parameters early (Tier 1 & 2)
         self._validate_initial_conditions(
@@ -2812,9 +2821,13 @@ class ClusterlessDetector(_DetectorBase):
             details.
         local_position_std : float or None, optional
             Anchor-width parameter for the multi-bin Local state's
-            spatial-anchor kernel. See ``_DetectorBase`` for details
-            (``None`` = legacy single-bin Local; ``0.0`` = delta kernel;
-            ``> 0`` = unnormalized ``-0.5 * d² / σ²`` anchor).
+            spatial-anchor kernel, rescaled per timestep so
+            ``exp(log_kernel)`` sums to ``n_bins`` (HMM-state mass
+            calibration; cancels the multi-bin Local state's uniform
+            ``1/n_bins`` continuous IC). See ``_DetectorBase`` for
+            details. ``None`` = legacy single-bin Local; ``0.0`` =
+            delta kernel; ``> 0`` = ``raw - logsumexp(raw) +
+            log(n_bins)`` with ``raw = -0.5 * d² / σ²``.
         """
         super().__init__(
             discrete_initial_conditions,
@@ -3766,9 +3779,13 @@ class SortedSpikesDetector(_DetectorBase):
             details.
         local_position_std : float or None, optional
             Anchor-width parameter for the multi-bin Local state's
-            spatial-anchor kernel. See ``_DetectorBase`` for details
-            (``None`` = legacy single-bin Local; ``0.0`` = delta kernel;
-            ``> 0`` = unnormalized ``-0.5 * d² / σ²`` anchor).
+            spatial-anchor kernel, rescaled per timestep so
+            ``exp(log_kernel)`` sums to ``n_bins`` (HMM-state mass
+            calibration; cancels the multi-bin Local state's uniform
+            ``1/n_bins`` continuous IC). See ``_DetectorBase`` for
+            details. ``None`` = legacy single-bin Local; ``0.0`` =
+            delta kernel; ``> 0`` = ``raw - logsumexp(raw) +
+            log(n_bins)`` with ``raw = -0.5 * d² / σ²``.
         """
         super().__init__(
             discrete_initial_conditions,

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -559,6 +559,30 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         sq_dist = jnp.nan_to_num(jnp.asarray(dist) ** 2, nan=jnp.inf, posinf=jnp.inf)
         return sq_dist, nan_mask
 
+    def _local_position_density_dim(self, environment: "Environment") -> int:
+        """Dimensionality of the Local-state Gaussian radial likelihood.
+
+        - Explicit linearized track (``track_graph is not None``): 1D
+          manifold density on shortest-path graph distance.
+        - Otherwise (``track_graphDD`` built by ``fit_place_grid`` for
+          2D / N-D occupancy grids, or the rare Euclidean fallback):
+          isotropic Gaussian on the position grid's coordinate
+          dimension.
+
+        Note: this is a radial likelihood using graph/geodesic distance,
+        not an exact normalized heat kernel on an arbitrary graph with
+        holes/boundaries. The choice is a modeling assumption, not a
+        derivation from graph Laplacian theory.
+        """
+        if environment.track_graph is not None:
+            return 1
+        if environment.place_bin_centers_ is None:
+            raise ValueError(
+                "environment.place_bin_centers_ is None; "
+                "fit the environment before computing the Local kernel."
+            )
+        return int(environment.place_bin_centers_.shape[1])
+
     def _compute_local_position_kernel(
         self,
         time: jnp.ndarray,
@@ -568,21 +592,28 @@ class _DetectorBase(BaseEstimator, abc.ABC):
     ) -> jnp.ndarray:
         """Compute log observation density for the multi-bin Local state.
 
-        For ``σ > 0`` returns a Gaussian density:
+        For ``σ > 0`` returns an isotropic Gaussian *radial* likelihood:
 
         ``log_kernel(t, b) = -0.5 * n_dims * log(2π σ²) - 0.5 * d(b, animal_t)² / σ²``
 
         where ``σ = local_position_std`` and ``d`` and ``n_dims`` depend on
-        the environment:
+        the environment (see :meth:`_local_position_density_dim`):
 
-        - **Track graph fitted**: ``d`` is shortest-path graph distance
-          (1D manifold), so the kernel is a 1D Gaussian with
-          ``n_dims = 1``.
-        - **Euclidean fallback** (no track graph): ``d`` is Euclidean
-          distance ``‖animal − bin_center‖`` in ``n_dims`` dimensions
-          (open-field case; ``n_dims = environment.place_bin_centers_.shape[1]``),
-          so the kernel is the n_dims-isotropic Gaussian with the
-          matching normalizer.
+        - **Explicit linearized track** (``track_graph`` set): ``d`` is
+          shortest-path graph distance on a 1D manifold; ``n_dims = 1``.
+        - **2D / N-D occupancy grid** (``track_graphDD`` built by
+          ``Environment.fit_place_grid``, the default for fitted N-D
+          environments): ``d`` is graph/geodesic distance on the grid;
+          ``n_dims`` is the position grid's coordinate dimension.
+        - **Euclidean fallback** (no distance matrix): ``d`` is
+          Euclidean ``‖animal − bin_center‖``; same ``n_dims``.
+
+        This is a *radial* likelihood using graph/geodesic distance —
+        not an exact normalized heat kernel on an arbitrary graph with
+        holes/boundaries. The choice is a modeling assumption: σ has
+        units of distance, and the per-bin density treats the
+        animal-to-bin distance as the only quantity governing the
+        observation likelihood.
 
         For ``σ == 0`` returns the delta-kernel limit: ``0`` at the
         animal's snapped interior bin, ``-inf`` elsewhere. Local mass
@@ -635,15 +666,7 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             time, position_time, position, environment
         )
 
-        # Track-graph and N-D distance-matrix paths return shortest-path
-        # distance on a 1D manifold (univariate), so the 1D Gaussian
-        # normalizer is correct. The Euclidean fallback computes
-        # ‖animal − bin_center‖ in n_dims-dim space, where the isotropic
-        # Gaussian normalizer is ``-0.5 * n_dims * log(2πσ²)``.
-        if environment.track_graph is not None:
-            n_dims = 1
-        else:
-            n_dims = int(environment.place_bin_centers_.shape[1])
+        n_dims = self._local_position_density_dim(environment)
         log_norm = -0.5 * n_dims * jnp.log(2.0 * jnp.pi * sigma**2)
 
         reachable = jnp.isfinite(sq_dist)

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -568,12 +568,21 @@ class _DetectorBase(BaseEstimator, abc.ABC):
     ) -> jnp.ndarray:
         """Compute log observation density for the multi-bin Local state.
 
-        For ``σ > 0`` returns a proper Gaussian density over position:
+        For ``σ > 0`` returns a Gaussian density:
 
-        ``log_kernel(t, b) = -0.5 * log(2π σ²) - 0.5 * d(b, animal_t)² / σ²``
+        ``log_kernel(t, b) = -0.5 * n_dims * log(2π σ²) - 0.5 * d(b, animal_t)² / σ²``
 
-        where ``d`` is shortest-path track-graph distance (Euclidean
-        fallback when no graph is fitted) and ``σ = local_position_std``.
+        where ``σ = local_position_std`` and ``d`` and ``n_dims`` depend on
+        the environment:
+
+        - **Track graph fitted**: ``d`` is shortest-path graph distance
+          (1D manifold), so the kernel is a 1D Gaussian with
+          ``n_dims = 1``.
+        - **Euclidean fallback** (no track graph): ``d`` is Euclidean
+          distance ``‖animal − bin_center‖`` in ``n_dims`` dimensions
+          (open-field case; ``n_dims = environment.place_bin_centers_.shape[1]``),
+          so the kernel is the n_dims-isotropic Gaussian with the
+          matching normalizer.
 
         For ``σ == 0`` returns the delta-kernel limit: ``0`` at the
         animal's snapped interior bin, ``-inf`` elsewhere. Local mass
@@ -626,7 +635,17 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             time, position_time, position, environment
         )
 
-        log_norm = -0.5 * jnp.log(2.0 * jnp.pi * sigma**2)
+        # Track-graph and N-D distance-matrix paths return shortest-path
+        # distance on a 1D manifold (univariate), so the 1D Gaussian
+        # normalizer is correct. The Euclidean fallback computes
+        # ‖animal − bin_center‖ in n_dims-dim space, where the isotropic
+        # Gaussian normalizer is ``-0.5 * n_dims * log(2πσ²)``.
+        if environment.track_graph is not None:
+            n_dims = 1
+        else:
+            n_dims = int(environment.place_bin_centers_.shape[1])
+        log_norm = -0.5 * n_dims * jnp.log(2.0 * jnp.pi * sigma**2)
+
         reachable = jnp.isfinite(sq_dist)
         log_kernel = jnp.where(
             reachable,

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -332,14 +332,12 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             - ``None`` (default): legacy behavior. Local state occupies a
               single bin; the likelihood is evaluated at the animal's
               exact interpolated position (continuous).
-            - ``0.0``: delta-kernel multi-bin local. Local state spans all
-              position bins, with all mass concentrated at the single bin
-              containing the animal (one-hot). Likelihood is evaluated at
-              bin centers (discrete).
-            - ``> 0``: multi-bin local with a Gaussian kernel of standard
-              deviation ``local_position_std`` (same units as ``position``,
-              typically centimeters) on the shortest-path track-graph
-              distance; models spatial uncertainty.
+            - ``> 0``: multi-bin local with a Gaussian observation density
+              of standard deviation ``local_position_std`` (same units as
+              ``position``, typically centimeters) on the shortest-path
+              track-graph distance; models the tracked-position
+              measurement noise. Pass a small positive value (e.g. 0.01)
+              for effectively-delta behavior.
         """
         # Validate all parameters early (Tier 1 & 2)
         self._validate_initial_conditions(
@@ -399,18 +397,19 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         self.no_spike_rate = no_spike_rate
 
         # Local position uncertainty parameter
-        if local_position_std is not None and local_position_std <= 0:
+        if local_position_std is not None and not (
+            np.isfinite(local_position_std) and local_position_std > 0
+        ):
             raise ValidationError(
-                "local_position_std must be strictly positive",
+                "local_position_std must be a finite, strictly positive float",
                 expected="float > 0 or None",
                 got=str(local_position_std),
                 hint=(
                     "Use None for legacy single-bin local (likelihood at "
-                    "the animal's exact interpolated position) or > 0 for "
-                    "a Gaussian kernel. Pass a small positive value (e.g. "
-                    "0.01) for effectively-delta behavior; the previous "
-                    "0.0 delta-kernel mode was removed because a Dirac "
-                    "density cannot be represented in log space."
+                    "the animal's exact interpolated position) or a finite "
+                    "positive value for a Gaussian observation density. "
+                    "Pass a small positive value (e.g. 0.01) for "
+                    "effectively-delta behavior."
                 ),
             )
         self.local_position_std = local_position_std
@@ -608,11 +607,13 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         else:
             nan_mask = jnp.any(jnp.isnan(animal_pos), axis=-1)
 
-        # Topology-aware distance via Environment.get_distances_to_interior_bins().
-        # After the get_bin_ind snap, the animal bin is always interior,
-        # so the distance-matrix row is always finite. Unreachable bins
-        # on disconnected components remain inf and become -inf log-density.
-        dist = environment.get_distances_to_interior_bins(np.asarray(animal_pos))
+        # NaN-safe input to the topology-aware distance lookup. The post-hoc
+        # ``nan_mask`` overwrite below makes the final result correct, but
+        # the distance helper goes through ``get_bin_ind`` -> ``np.searchsorted``
+        # which is undefined on NaN. Replace NaN coords with 0.0 first to
+        # mirror ``_compute_non_local_position_penalty`` (line ~528).
+        safe_animal_pos = np.nan_to_num(np.asarray(animal_pos), nan=0.0)
+        dist = environment.get_distances_to_interior_bins(safe_animal_pos)
         sq_dist = jnp.asarray(dist) ** 2
 
         log_norm = -0.5 * jnp.log(2.0 * jnp.pi * sigma**2)
@@ -2967,22 +2968,20 @@ class ClusterlessDetector(_DetectorBase):
         Notes
         -----
         When ``local_position_std`` is set, the per-bin value returned
-        for local-state entries is not a pure observation likelihood.
-        It combines the spatial spike likelihood with the position
-        uncertainty kernel::
+        for local-state entries is not a pure spike likelihood. It
+        combines the spatial spike likelihood with the Gaussian
+        observation density of the tracked position::
 
             log_likelihood[local, b, t] =
-                log P(spikes_t | bin b)                   # spatial likelihood
-              + log_kernel(b | animal_pos_t)              # Gaussian anchor
-              + log(n_interior_bins)                      # mass-balance
+                log P(spikes_t | bin b)               # spatial likelihood
+              + log N(d(b, animal_t); 0, σ²)          # tracked-position density
 
-        The kernel term is a time-varying state-specific spatial prior.
-        Mathematically, injecting it into the likelihood is equivalent
-        to injecting it into the transition matrix — both multiply into
+        where ``d`` is shortest-path track-graph distance and
+        ``σ = local_position_std``. Mathematically, injecting the
+        tracked-position density into the likelihood is equivalent to
+        injecting it into the transition matrix — both multiply into
         the HMM forward step — but avoids breaking the static-transition
-        assumption used by ``jax.lax.scan``. The ``log(n_interior_bins)``
-        constant compensates for the ``1/n_bins`` uniform continuous IC
-        so the effective per-bin prior is ``exp(log_kernel)`` itself.
+        assumption used by ``jax.lax.scan``.
 
         The kernel is part of the likelihood model, not an ad-hoc
         post-processing step, so the posterior returned by ``predict()``
@@ -2992,7 +2991,7 @@ class ClusterlessDetector(_DetectorBase):
         differ); users reading the raw ``log_likelihood`` (via
         ``return_outputs='log_likelihood'``) should be aware that
         local-state entries are *not* pure ``log P(spikes | state, bin)``
-        — they include the kernel and mass-balance terms.
+        — they include the Gaussian observation density.
 
         Parameters
         ----------
@@ -3899,22 +3898,20 @@ class SortedSpikesDetector(_DetectorBase):
         Notes
         -----
         When ``local_position_std`` is set, the per-bin value returned
-        for local-state entries is not a pure observation likelihood.
-        It combines the spatial spike likelihood with the position
-        uncertainty kernel::
+        for local-state entries is not a pure spike likelihood. It
+        combines the spatial spike likelihood with the Gaussian
+        observation density of the tracked position::
 
             log_likelihood[local, b, t] =
-                log P(spikes_t | bin b)                   # spatial likelihood
-              + log_kernel(b | animal_pos_t)              # Gaussian anchor
-              + log(n_interior_bins)                      # mass-balance
+                log P(spikes_t | bin b)               # spatial likelihood
+              + log N(d(b, animal_t); 0, σ²)          # tracked-position density
 
-        The kernel term is a time-varying state-specific spatial prior.
-        Mathematically, injecting it into the likelihood is equivalent
-        to injecting it into the transition matrix — both multiply into
+        where ``d`` is shortest-path track-graph distance and
+        ``σ = local_position_std``. Mathematically, injecting the
+        tracked-position density into the likelihood is equivalent to
+        injecting it into the transition matrix — both multiply into
         the HMM forward step — but avoids breaking the static-transition
-        assumption used by ``jax.lax.scan``. The ``log(n_interior_bins)``
-        constant compensates for the ``1/n_bins`` uniform continuous IC
-        so the effective per-bin prior is ``exp(log_kernel)`` itself.
+        assumption used by ``jax.lax.scan``.
 
         The kernel is part of the likelihood model, not an ad-hoc
         post-processing step, so the posterior returned by ``predict()``
@@ -3924,7 +3921,7 @@ class SortedSpikesDetector(_DetectorBase):
         differ); users reading the raw ``log_likelihood`` (via
         ``return_outputs='log_likelihood'``) should be aware that
         local-state entries are *not* pure ``log P(spikes | state, bin)``
-        — they include the kernel and mass-balance terms.
+        — they include the Gaussian observation density.
 
         Parameters
         ----------

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -525,6 +525,39 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         # dependent bin.
         return jnp.where(nan_mask[:, jnp.newaxis], 0.0, penalty)
 
+    def _extract_animal_position(
+        self,
+        time: jnp.ndarray,
+        position_time: jnp.ndarray,
+        position: jnp.ndarray,
+        environment: "Environment",
+    ) -> tuple[np.ndarray, jnp.ndarray]:
+        """NaN-safe interpolated animal position and a NaN-row mask.
+
+        ``get_bin_ind`` and ``get_distances_to_interior_bins`` go through
+        ``np.searchsorted``, which is undefined on NaN. Replace NaN coords
+        with 0.0 before any downstream lookup; callers use ``nan_mask`` to
+        zero out the corresponding rows of the result.
+
+        Returns
+        -------
+        safe_animal_pos : np.ndarray, shape (n_time, n_position_dims)
+            Always 2D (1D inputs are reshaped) so callers can pass directly
+            to ``Environment`` lookups.
+        nan_mask : jnp.ndarray, shape (n_time,)  bool
+        """
+        from non_local_detector.likelihoods.common import get_position_at_time
+
+        animal_pos = get_position_at_time(position_time, position, time, environment)
+        animal_pos_arr = np.asarray(animal_pos)
+        if animal_pos_arr.ndim == 1:
+            nan_mask = jnp.isnan(jnp.asarray(animal_pos_arr))
+            animal_pos_arr = animal_pos_arr[:, np.newaxis]
+        else:
+            nan_mask = jnp.any(jnp.isnan(jnp.asarray(animal_pos_arr)), axis=-1)
+        safe_animal_pos = np.nan_to_num(animal_pos_arr, nan=0.0)
+        return safe_animal_pos, nan_mask
+
     def _animal_sq_distance_to_interior_bins(
         self,
         time: jnp.ndarray,
@@ -534,9 +567,6 @@ class _DetectorBase(BaseEstimator, abc.ABC):
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
         """NaN-safe squared track-graph distances and a NaN-row mask.
 
-        ``get_bin_ind`` goes through ``np.searchsorted``, which is undefined
-        on NaN. Replace NaN coords with 0.0 before the distance lookup, then
-        let callers use the returned mask to zero out NaN-row outputs.
         Non-finite distances (NaN bin-to-bin lookups, inf unreachable bins)
         are mapped to ``inf`` so ``exp(-0.5 * inf / σ²) == 0`` cleanly.
 
@@ -545,34 +575,20 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         sq_dist : jnp.ndarray, shape (n_time, n_interior_bins)
         nan_mask : jnp.ndarray, shape (n_time,)  bool
         """
-        from non_local_detector.likelihoods.common import get_position_at_time
-
-        animal_pos = get_position_at_time(position_time, position, time, environment)
-        animal_pos_arr = np.asarray(animal_pos)
-        if animal_pos_arr.ndim == 1:
-            nan_mask = jnp.isnan(jnp.asarray(animal_pos_arr))
-        else:
-            nan_mask = jnp.any(jnp.isnan(jnp.asarray(animal_pos_arr)), axis=-1)
-
-        safe_animal_pos = np.nan_to_num(animal_pos_arr, nan=0.0)
+        safe_animal_pos, nan_mask = self._extract_animal_position(
+            time, position_time, position, environment
+        )
         dist = environment.get_distances_to_interior_bins(safe_animal_pos)
         sq_dist = jnp.nan_to_num(jnp.asarray(dist) ** 2, nan=jnp.inf, posinf=jnp.inf)
         return sq_dist, nan_mask
 
     def _local_position_density_dim(self, environment: "Environment") -> int:
-        """Dimensionality of the Local-state Gaussian radial likelihood.
+        """Dimensionality used in the Local-state Gaussian radial likelihood.
 
-        - Explicit linearized track (``track_graph is not None``): 1D
-          manifold density on shortest-path graph distance.
-        - Otherwise (``track_graphDD`` built by ``fit_place_grid`` for
-          2D / N-D occupancy grids, or the rare Euclidean fallback):
-          isotropic Gaussian on the position grid's coordinate
-          dimension.
-
-        Note: this is a radial likelihood using graph/geodesic distance,
-        not an exact normalized heat kernel on an arbitrary graph with
-        holes/boundaries. The choice is a modeling assumption, not a
-        derivation from graph Laplacian theory.
+        Returns 1 for explicit linearized tracks (``track_graph is not None``)
+        and the position grid's coordinate dimension otherwise. See
+        :meth:`_compute_local_position_kernel` for the full kernel formula
+        and the modeling-assumption caveat.
         """
         if environment.track_graph is not None:
             return 1
@@ -693,18 +709,9 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         the animal's bin. NaN animal positions fall back to a flat kernel
         as in the Gaussian path.
         """
-        from non_local_detector.likelihoods.common import get_position_at_time
-
-        animal_pos = get_position_at_time(position_time, position, time, environment)
-        animal_pos_arr = np.asarray(animal_pos)
-        if animal_pos_arr.ndim == 1:
-            nan_mask = jnp.isnan(jnp.asarray(animal_pos_arr))
-        else:
-            nan_mask = jnp.any(jnp.isnan(jnp.asarray(animal_pos_arr)), axis=-1)
-
-        safe_animal_pos = np.nan_to_num(animal_pos_arr, nan=0.0)
-        if safe_animal_pos.ndim == 1:
-            safe_animal_pos = safe_animal_pos[:, np.newaxis]
+        safe_animal_pos, nan_mask = self._extract_animal_position(
+            time, position_time, position, environment
+        )
         animal_bin_inds = environment.get_bin_ind(safe_animal_pos)
         interior_bin_indices = np.where(environment.is_track_interior_.ravel())[0]
         is_animal_bin = jnp.asarray(
@@ -1231,6 +1238,28 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             return None
         continuous_ic = np.concatenate(ic_parts).astype(np.float32)
         return continuous_ic * self.discrete_initial_conditions[self.state_ind_]
+
+    def _initial_distribution_for_decode(
+        self,
+        time: np.ndarray,
+        log_likelihood_args: tuple,
+        is_track_interior: np.ndarray,
+    ) -> np.ndarray:
+        """Initial state distribution for a single decode call (predict / Viterbi).
+
+        Returns the multi-bin Local override sliced to interior bins when it
+        applies, otherwise the interior-sliced stored
+        ``self.initial_conditions_``. Both ``_predict()`` and
+        ``most_likely_sequence()`` go through this so they always see the
+        same initial Local distribution. Stored attribute is not mutated.
+        """
+        position_time = (
+            log_likelihood_args[0] if len(log_likelihood_args) >= 2 else None
+        )
+        position = log_likelihood_args[1] if len(log_likelihood_args) >= 2 else None
+        override = self.compute_local_initial_conditions(position_time, position, time)
+        full = override if override is not None else self.initial_conditions_
+        return full[is_track_interior]
 
     def initialize_initial_conditions(self) -> None:
         """Constructs the initial probability for the state and each spatial bin.
@@ -1813,19 +1842,9 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         cross_is_track_interior = np.ix_(is_track_interior, is_track_interior)
         state_ind = self.state_ind_[is_track_interior]
 
-        # When the multi-bin Local state is configured and position data is
-        # available in ``log_likelihood_args[:2]``, replace the Local rows
-        # of the IC with a delta at the animal's first-frame bin. Stored
-        # ``self.initial_conditions_`` is not mutated.
-        position_time = (
-            log_likelihood_args[0] if len(log_likelihood_args) >= 2 else None
+        initial_distribution = self._initial_distribution_for_decode(
+            time, log_likelihood_args, is_track_interior
         )
-        position = log_likelihood_args[1] if len(log_likelihood_args) >= 2 else None
-        override = self.compute_local_initial_conditions(position_time, position, time)
-        initial_conditions_full = (
-            override if override is not None else self.initial_conditions_
-        )
-        initial_distribution = initial_conditions_full[is_track_interior]
 
         # Use provided transitions or fall back to fitted attribute
         discrete_transitions = (
@@ -2261,17 +2280,9 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         cross_is_track_interior = np.ix_(is_track_interior, is_track_interior)
         state_ind = self.state_ind_[is_track_interior]
 
-        # Mirror _predict()'s multi-bin Local IC override so Viterbi and the
-        # forward-backward smoother see the same initial Local distribution.
-        position_time = (
-            log_likelihood_args[0] if len(log_likelihood_args) >= 2 else None
+        initial_distribution = self._initial_distribution_for_decode(
+            time, log_likelihood_args, is_track_interior
         )
-        position = log_likelihood_args[1] if len(log_likelihood_args) >= 2 else None
-        override = self.compute_local_initial_conditions(position_time, position, time)
-        initial_conditions_full = (
-            override if override is not None else self.initial_conditions_
-        )
-        initial_distribution = initial_conditions_full[is_track_interior]
 
         if self.discrete_state_transitions_.ndim == 2:
             sequence_ind, _ = most_likely_sequence(

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -3046,9 +3046,12 @@ class ClusterlessDetector(_DetectorBase):
         but avoids breaking the static-transition assumption used by
         ``jax.lax.scan``.
 
-        The kernel is part of the model, not an ad-hoc post-processing
-        step, so the posterior returned by ``predict()`` is a valid
-        probability distribution under the modified generative model.
+        The anchor is part of the scoring model, not an ad-hoc
+        post-processing step, so the posterior returned by ``predict()``
+        is a valid probability distribution under the modified scoring
+        model (the anchor is an unnormalized potential, not a calibrated
+        emission density, so this is not a generative model in the
+        strict sense).
         Users comparing ``local_position_std=None`` to a finite value
         will see different posteriors (the models differ); users reading
         the raw ``log_likelihood`` (via
@@ -3982,9 +3985,12 @@ class SortedSpikesDetector(_DetectorBase):
         but avoids breaking the static-transition assumption used by
         ``jax.lax.scan``.
 
-        The kernel is part of the model, not an ad-hoc post-processing
-        step, so the posterior returned by ``predict()`` is a valid
-        probability distribution under the modified generative model.
+        The anchor is part of the scoring model, not an ad-hoc
+        post-processing step, so the posterior returned by ``predict()``
+        is a valid probability distribution under the modified scoring
+        model (the anchor is an unnormalized potential, not a calibrated
+        emission density, so this is not a generative model in the
+        strict sense).
         Users comparing ``local_position_std=None`` to a finite value
         will see different posteriors (the models differ); users reading
         the raw ``log_likelihood`` (via

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -6,6 +6,7 @@ import warnings
 from collections.abc import Callable
 from logging import getLogger
 
+import jax
 import jax.numpy as jnp
 import matplotlib
 import matplotlib.pyplot as plt
@@ -619,26 +620,29 @@ class _DetectorBase(BaseEstimator, abc.ABC):
     ) -> jnp.ndarray:
         """Spatial-anchor log-kernel for the multi-bin Local state.
 
-        For ``σ > 0`` returns the *unnormalized* anchor:
+        For ``σ > 0`` returns the anchor potential, normalized so that
+        ``exp(log_kernel)`` sums to ``n_bins`` per timestep:
 
-        ``log_kernel(t, b) = -0.5 * d(b, animal_t)² / σ²``
+        ``log_kernel(t, b) = raw(t, b) - logsumexp(raw(t, ·)) + log(n_bins)``
 
-        where ``d`` is shortest-path graph/geodesic distance (Euclidean
-        fallback when no distance matrix is fitted) and
-        ``σ = local_position_std``. The peak is always 0 at the animal's
-        bin and falls off with distance, so ``σ`` controls the *spatial
-        tolerance* of the Local state — how far from the animal a Local
-        bin can be while still being credible — without re-weighting the
-        Local-vs-non-Local global evidence balance via a normalizer.
+        where ``raw(t, b) = -0.5 * d(b, animal_t)² / σ²`` and ``d`` is
+        shortest-path graph/geodesic distance (Euclidean fallback when
+        no distance matrix is fitted). This is *not* density
+        normalization — it is HMM-state mass-balance calibration. The
+        multi-bin Local state has a uniform ``1 / n_bins`` continuous
+        prior, which would otherwise shrink the Local state's evidence
+        by a factor of ``n_bins`` relative to Non-Local on the forward
+        pass; rescaling the kernel to sum to ``n_bins`` cancels that
+        factor exactly. Without this scaling, Non-Local dominates by a
+        factor of ``n_bins`` regardless of σ.
 
-        This is **not** a normalized density; integrating
-        ``exp(log_kernel)`` over bins varies with σ and bin spacing.
-        Treat ``local_position_std`` as an anchor-width hyperparameter,
+        Treat ``σ = local_position_std`` as an anchor-width
+        hyperparameter (controls spatial tolerance of the Local state),
         not a calibrated measurement-noise scale.
 
-        For ``σ == 0`` returns the delta-kernel limit: ``0`` at the
-        animal's snapped interior bin, ``-inf`` elsewhere. Local mass
-        commits exactly to that bin per timestep.
+        For ``σ == 0`` returns the delta-kernel limit: ``log(n_bins)``
+        at the animal's snapped interior bin, ``-inf`` elsewhere — the
+        same ``n_bins`` mass-balance scaling reduced to a single bin.
 
         Gap-bin positions (e.g. exactly on an arm-boundary edge) are
         snapped to the nearest interior bin via
@@ -665,7 +669,8 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         Returns
         -------
         log_kernel : jnp.ndarray, shape (n_time, n_interior_bins)
-            Spatial-anchor log-kernel; peak is 0 at the animal's bin.
+            Spatial-anchor log-kernel, normalized so
+            ``exp(log_kernel)`` sums to ``n_bins`` per timestep.
         """
         assert self.local_position_std is not None  # narrowing for type checker
 
@@ -679,12 +684,18 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             time, position_time, position, environment
         )
 
+        n_bins = sq_dist.shape[1]
+        log_n_bins = jnp.log(jnp.array(n_bins, dtype=jnp.float32))
+
         reachable = jnp.isfinite(sq_dist)
-        log_kernel = jnp.where(
-            reachable,
-            -0.5 * sq_dist / (sigma**2),
-            -jnp.inf,
+        raw = jnp.where(reachable, -0.5 * sq_dist / (sigma**2), -jnp.inf)
+        # Mass-balance: rescale so exp(log_kernel).sum(axis=1) == n_bins.
+        # Compensates for the multi-bin Local state's uniform 1/n_bins
+        # continuous IC; without it, Non-Local dominates by factor n_bins.
+        log_kernel = (
+            raw - jax.scipy.special.logsumexp(raw, axis=1, keepdims=True) + log_n_bins
         )
+
         # NaN animal positions (tracking dropout) → flat kernel at that step.
         log_kernel = jnp.where(nan_mask[:, jnp.newaxis], 0.0, log_kernel)
         return log_kernel
@@ -696,12 +707,17 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         position: jnp.ndarray,
         environment: "Environment",
     ) -> jnp.ndarray:
-        """One-hot kernel for the σ=0 limit of the multi-bin Local state.
+        """Delta-kernel for the σ=0 limit of the multi-bin Local state.
 
-        Returns ``log_kernel = 0`` at the animal's snapped interior bin and
-        ``-inf`` elsewhere, so the per-step Local state commits exactly to
-        the animal's bin. NaN animal positions fall back to a flat kernel
-        as in the Gaussian path.
+        Returns ``log_kernel = log(n_bins)`` at the animal's snapped
+        interior bin and ``-inf`` elsewhere, so ``exp(log_kernel)`` sums
+        to ``n_bins`` per timestep — the same mass-balance scaling
+        applied in the σ>0 path. This compensates for the multi-bin
+        Local state's uniform ``1/n_bins`` continuous IC; without it,
+        Non-Local dominates by a factor of ``n_bins``.
+
+        NaN animal positions (tracking dropouts) fall back to a flat
+        ``log_kernel = 0`` for that timestep.
         """
         safe_animal_pos, nan_mask = self._extract_animal_position(
             time, position_time, position, environment
@@ -711,7 +727,9 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         is_animal_bin = jnp.asarray(
             animal_bin_inds[:, np.newaxis] == interior_bin_indices[np.newaxis, :]
         )
-        log_kernel = jnp.where(is_animal_bin, 0.0, -jnp.inf)
+        n_bins = int(interior_bin_indices.size)
+        log_n_bins = jnp.log(jnp.array(n_bins, dtype=jnp.float32))
+        log_kernel = jnp.where(is_animal_bin, log_n_bins, -jnp.inf)
         return jnp.where(nan_mask[:, jnp.newaxis], 0.0, log_kernel)
 
     def _validate_initial_conditions(
@@ -1196,9 +1214,11 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             return None
 
         override = np.array(self.initial_conditions_, copy=True)
+        any_local = False
         for state_id, obs in enumerate(self.observation_models):
             if not obs.is_local:
                 continue
+            any_local = True
             env = self.environments[self.environments.index(obs.environment_name)]
             animal_pos_t0 = np.asarray(
                 get_position_at_time(
@@ -1208,13 +1228,17 @@ class _DetectorBase(BaseEstimator, abc.ABC):
                     env,
                 )
             )
+            # NaN at t=0 → skip just this Local state (leave its stored
+            # block untouched). Other Local states (multi-environment
+            # configurations) can still receive a delta override.
             if np.any(np.isnan(animal_pos_t0)):
                 logger.warning(
-                    "Multi-bin Local IC override skipped: first decoding "
-                    "frame's interpolated position is NaN. Stored Local "
-                    "IC will be used."
+                    "Multi-bin Local IC override skipped for state %d: "
+                    "first decoding frame's interpolated position is NaN. "
+                    "Stored Local IC will be used for this state.",
+                    state_id,
                 )
-                return None
+                continue
 
             animal_pos_2d = (
                 animal_pos_t0
@@ -1228,6 +1252,8 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             block[animal_bin] = float(self.discrete_initial_conditions[state_id])
             override[block_mask] = block
 
+        if not any_local:
+            return None
         return override
 
     def _initial_distribution_for_decode(
@@ -1244,6 +1270,12 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         ``most_likely_sequence()`` go through this so they always see the
         same initial Local distribution. Stored attribute is not mutated.
         """
+        # `log_likelihood_args` is normally a 4-tuple
+        # (position_time, position, ...), but `estimate_parameters` calls
+        # this helper with `log_likelihood_args=()` when reusing a cached
+        # likelihood — the override is unavailable in that path. Guard
+        # the indexing so the caller transparently falls back to the
+        # stored uniform Local IC.
         position_time = (
             log_likelihood_args[0] if len(log_likelihood_args) >= 2 else None
         )
@@ -2779,8 +2811,10 @@ class ClusterlessDetector(_DetectorBase):
             re-estimation, by default None. See ``_DetectorBase`` for
             details.
         local_position_std : float or None, optional
-            Standard deviation of the position uncertainty kernel for the
-            local state. See ``_DetectorBase`` for details.
+            Anchor-width parameter for the multi-bin Local state's
+            spatial-anchor kernel. See ``_DetectorBase`` for details
+            (``None`` = legacy single-bin Local; ``0.0`` = delta kernel;
+            ``> 0`` = unnormalized ``-0.5 * d² / σ²`` anchor).
         """
         super().__init__(
             discrete_initial_conditions,
@@ -3057,16 +3091,22 @@ class ClusterlessDetector(_DetectorBase):
                 log P(spikes_t | bin b)               # spatial likelihood
               + log_kernel(b, animal_t)               # anchor: peak 0 at animal_t
 
-        where ``log_kernel = -0.5 * d² / σ²`` with ``σ =
-        local_position_std``. The kernel is *not* a normalized density
-        (no ``log(2π σ²)`` term); ``σ`` controls Local's spatial
-        tolerance — how far from the animal a Local bin remains
-        credible — without re-weighting Local-vs-non-Local global
-        evidence via a normalizer. Mathematically, injecting this term
-        into the likelihood is equivalent to injecting it into the
-        transition matrix — both multiply into the HMM forward step —
-        but avoids breaking the static-transition assumption used by
-        ``jax.lax.scan``.
+        where ``log_kernel`` is the spatial-anchor potential
+        ``raw = -0.5 * d² / σ²`` (with ``σ = local_position_std``)
+        rescaled per timestep so ``exp(log_kernel).sum(axis=1) ==
+        n_bins``. The rescaling is HMM-state mass calibration, not
+        density normalization: the multi-bin Local state has a uniform
+        ``1/n_bins`` continuous IC, and without the ``+ log(n_bins)``
+        compensation the Local state's evidence is shrunk by
+        ``1/n_bins`` relative to Non-Local. ``σ`` controls Local's
+        spatial tolerance — how far from the animal a Local bin
+        remains credible — independent of the Local-vs-Non-Local
+        balance. Conceptually this is a time-varying, per-target-state
+        potential (``log_kernel`` depends on the animal's current
+        position); folding it into the likelihood keeps the discrete
+        transition matrix row-stochastic and static, as required by
+        ``jax.lax.scan``. It is *not* equivalent to a valid
+        (row-stochastic) transition matrix.
 
         The anchor is part of the scoring model, not an ad-hoc
         post-processing step, so the posterior returned by ``predict()``
@@ -3725,8 +3765,10 @@ class SortedSpikesDetector(_DetectorBase):
             re-estimation, by default None. See ``_DetectorBase`` for
             details.
         local_position_std : float or None, optional
-            Standard deviation of the position uncertainty kernel for the
-            local state. See ``_DetectorBase`` for details.
+            Anchor-width parameter for the multi-bin Local state's
+            spatial-anchor kernel. See ``_DetectorBase`` for details
+            (``None`` = legacy single-bin Local; ``0.0`` = delta kernel;
+            ``> 0`` = unnormalized ``-0.5 * d² / σ²`` anchor).
         """
         super().__init__(
             discrete_initial_conditions,
@@ -3996,16 +4038,22 @@ class SortedSpikesDetector(_DetectorBase):
                 log P(spikes_t | bin b)               # spatial likelihood
               + log_kernel(b, animal_t)               # anchor: peak 0 at animal_t
 
-        where ``log_kernel = -0.5 * d² / σ²`` with ``σ =
-        local_position_std``. The kernel is *not* a normalized density
-        (no ``log(2π σ²)`` term); ``σ`` controls Local's spatial
-        tolerance — how far from the animal a Local bin remains
-        credible — without re-weighting Local-vs-non-Local global
-        evidence via a normalizer. Mathematically, injecting this term
-        into the likelihood is equivalent to injecting it into the
-        transition matrix — both multiply into the HMM forward step —
-        but avoids breaking the static-transition assumption used by
-        ``jax.lax.scan``.
+        where ``log_kernel`` is the spatial-anchor potential
+        ``raw = -0.5 * d² / σ²`` (with ``σ = local_position_std``)
+        rescaled per timestep so ``exp(log_kernel).sum(axis=1) ==
+        n_bins``. The rescaling is HMM-state mass calibration, not
+        density normalization: the multi-bin Local state has a uniform
+        ``1/n_bins`` continuous IC, and without the ``+ log(n_bins)``
+        compensation the Local state's evidence is shrunk by
+        ``1/n_bins`` relative to Non-Local. ``σ`` controls Local's
+        spatial tolerance — how far from the animal a Local bin
+        remains credible — independent of the Local-vs-Non-Local
+        balance. Conceptually this is a time-varying, per-target-state
+        potential (``log_kernel`` depends on the animal's current
+        position); folding it into the likelihood keeps the discrete
+        transition matrix row-stochastic and static, as required by
+        ``jax.lax.scan``. It is *not* equivalent to a valid
+        (row-stochastic) transition matrix.
 
         The anchor is part of the scoring model, not an ad-hoc
         post-processing step, so the posterior returned by ``predict()``

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -333,12 +333,15 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             - ``None`` (default): legacy behavior. Local state occupies a
               single bin; the likelihood is evaluated at the animal's
               exact interpolated position (continuous).
-            - ``> 0``: multi-bin local with a Gaussian observation density
-              of standard deviation ``local_position_std`` (same units as
-              ``position``, typically centimeters) on the shortest-path
-              track-graph distance; models the tracked-position
-              measurement noise. Pass a small positive value (e.g. 0.01)
-              for effectively-delta behavior.
+            - ``0.0``: multi-bin Local with a delta kernel that commits
+              Local mass to the animal's snapped interior bin per
+              timestep (one-hot kernel: ``log_kernel = 0`` at the bin
+              and ``-inf`` elsewhere).
+            - ``> 0``: multi-bin Local with a Gaussian observation
+              density of standard deviation ``local_position_std`` (same
+              units as ``position``, typically centimeters) on the
+              shortest-path track-graph distance; models the
+              tracked-position measurement noise.
         """
         # Validate all parameters early (Tier 1 & 2)
         self._validate_initial_conditions(
@@ -399,17 +402,18 @@ class _DetectorBase(BaseEstimator, abc.ABC):
 
         if local_position_std is not None:
             val.ensure_positive_scalar(
-                local_position_std, "local_position_std", minimum=0.0, strict=True
+                local_position_std, "local_position_std", minimum=0.0, strict=False
             )
             if not np.isfinite(local_position_std):
                 raise ValidationError(
                     "local_position_std must be finite",
-                    expected="finite float > 0 or None",
+                    expected="finite float >= 0 or None",
                     got=str(local_position_std),
                     hint=(
-                        "Use None for legacy single-bin local or a finite "
-                        "positive value (e.g. 0.01 for near-delta) for a "
-                        "Gaussian observation density."
+                        "Use None for legacy single-bin local, 0.0 for a "
+                        "delta kernel that commits Local mass to the "
+                        "animal's bin per timestep, or a finite positive "
+                        "value for a Gaussian observation density."
                     ),
                 )
         self.local_position_std = local_position_std
@@ -564,12 +568,16 @@ class _DetectorBase(BaseEstimator, abc.ABC):
     ) -> jnp.ndarray:
         """Compute log observation density for the multi-bin Local state.
 
-        Returns the log of a proper Gaussian density over position:
+        For ``σ > 0`` returns a proper Gaussian density over position:
 
         ``log_kernel(t, b) = -0.5 * log(2π σ²) - 0.5 * d(b, animal_t)² / σ²``
 
         where ``d`` is shortest-path track-graph distance (Euclidean
         fallback when no graph is fitted) and ``σ = local_position_std``.
+
+        For ``σ == 0`` returns the delta-kernel limit: ``0`` at the
+        animal's snapped interior bin, ``-inf`` elsewhere. Local mass
+        commits exactly to that bin per timestep.
 
         This is the observation channel of the Local state: it expresses
         ``P(animal_t | Local, bin=b)`` — how likely the animal's tracked
@@ -607,8 +615,13 @@ class _DetectorBase(BaseEstimator, abc.ABC):
             bin as the mean.
         """
         assert self.local_position_std is not None  # narrowing for type checker
-        sigma = jnp.asarray(self.local_position_std, dtype=jnp.float32)
 
+        if self.local_position_std == 0:
+            return self._compute_local_delta_kernel(
+                time, position_time, position, environment
+            )
+
+        sigma = jnp.asarray(self.local_position_std, dtype=jnp.float32)
         sq_dist, nan_mask = self._animal_sq_distance_to_interior_bins(
             time, position_time, position, environment
         )
@@ -623,6 +636,40 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         # NaN animal positions (tracking dropout) → flat kernel at that step.
         log_kernel = jnp.where(nan_mask[:, jnp.newaxis], 0.0, log_kernel)
         return log_kernel
+
+    def _compute_local_delta_kernel(
+        self,
+        time: jnp.ndarray,
+        position_time: jnp.ndarray,
+        position: jnp.ndarray,
+        environment: "Environment",
+    ) -> jnp.ndarray:
+        """One-hot kernel for the σ=0 limit of the multi-bin Local state.
+
+        Returns ``log_kernel = 0`` at the animal's snapped interior bin and
+        ``-inf`` elsewhere, so the per-step Local state commits exactly to
+        the animal's bin. NaN animal positions fall back to a flat kernel
+        as in the Gaussian path.
+        """
+        from non_local_detector.likelihoods.common import get_position_at_time
+
+        animal_pos = get_position_at_time(position_time, position, time, environment)
+        animal_pos_arr = np.asarray(animal_pos)
+        if animal_pos_arr.ndim == 1:
+            nan_mask = jnp.isnan(jnp.asarray(animal_pos_arr))
+        else:
+            nan_mask = jnp.any(jnp.isnan(jnp.asarray(animal_pos_arr)), axis=-1)
+
+        safe_animal_pos = np.nan_to_num(animal_pos_arr, nan=0.0)
+        if safe_animal_pos.ndim == 1:
+            safe_animal_pos = safe_animal_pos[:, np.newaxis]
+        animal_bin_inds = environment.get_bin_ind(safe_animal_pos)
+        interior_bin_indices = np.where(environment.is_track_interior_.ravel())[0]
+        is_animal_bin = jnp.asarray(
+            animal_bin_inds[:, np.newaxis] == interior_bin_indices[np.newaxis, :]
+        )
+        log_kernel = jnp.where(is_animal_bin, 0.0, -jnp.inf)
+        return jnp.where(nan_mask[:, jnp.newaxis], 0.0, log_kernel)
 
     def _validate_initial_conditions(
         self,

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -1027,13 +1027,26 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         """Return the initial conditions to use for a single ``_predict()`` call.
 
         Falls back to ``self.initial_conditions_`` when the multi-bin Local
-        override doesn't apply (legacy single-bin Local, no position data,
-        or NaN initial position). Otherwise returns the full IC with the
-        Local rows replaced by a delta at the animal's first-bin.
+        override doesn't apply (legacy single-bin Local, or no position data
+        is available — see :meth:`compute_local_initial_conditions`).
         """
-        position_time = log_likelihood_args[0] if len(log_likelihood_args) > 0 else None
-        position = log_likelihood_args[1] if len(log_likelihood_args) > 1 else None
-        override = self.compute_local_initial_conditions(position_time, position, time)
+        if self.local_position_std is None:
+            return self.initial_conditions_
+
+        if len(log_likelihood_args) < 2:
+            logger.warning(
+                "_predict() called with local_position_std=%g but "
+                "log_likelihood_args has only %d entries (expected position_time "
+                "at index 0 and position at index 1). Falling back to the stored "
+                "uniform Local initial conditions.",
+                self.local_position_std,
+                len(log_likelihood_args),
+            )
+            return self.initial_conditions_
+
+        override = self.compute_local_initial_conditions(
+            log_likelihood_args[0], log_likelihood_args[1], time
+        )
         return override if override is not None else self.initial_conditions_
 
     def compute_local_initial_conditions(
@@ -1042,23 +1055,23 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         position: np.ndarray | None,
         time: np.ndarray,
     ) -> np.ndarray | None:
-        """Predict-time initial conditions with the Local rows replaced by a
+        """Predict-time initial conditions with the Local block replaced by a
         delta at the bin containing the animal's first interpolated position.
 
-        The stored ``self.initial_conditions_`` keeps a uniform Local block
-        because the IC depends on test-time data and cannot be fit-time data.
-        ``predict()`` and ``estimate_parameters()`` call this helper at the
-        start of each run and pass the result to ``_predict()`` as an
-        override; the stored array is never mutated.
+        Returns a full IC array matching the shape of
+        ``self.initial_conditions_``. The stored attribute is never mutated.
 
-        Returns ``None`` (telling the caller to use the stored uniform IC)
-        when:
+        Returns ``None`` (signaling that the stored uniform Local IC should
+        be used unchanged) when:
 
         - ``self.local_position_std is None`` — legacy single-bin Local has
           no per-bin distribution to override.
-        - ``position`` or ``position_time`` is None.
-        - The interpolated animal position at ``time[0]`` is NaN
-          (tracking dropout on the initial frame).
+        - ``position`` or ``position_time`` is ``None`` — caller did not
+          supply position data.
+        - The interpolated animal position at ``time[0]`` is NaN — tracking
+          dropout on the initial frame. A warning is logged in this case
+          because a frame-0 dropout usually indicates an upstream pipeline
+          issue.
 
         Parameters
         ----------
@@ -1070,12 +1083,7 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         Returns
         -------
         override_initial_conditions : np.ndarray, shape (n_state_bins,) or None
-            Full IC array matching ``self.initial_conditions_``'s shape, with
-            Local rows replaced by a delta at the animal bin. ``None`` when
-            no override applies.
         """
-        from dataclasses import replace as dataclass_replace
-
         from non_local_detector.likelihoods.common import get_position_at_time
 
         if (
@@ -1103,31 +1111,48 @@ class _DetectorBase(BaseEstimator, abc.ABC):
                     )
                 )
                 if np.any(np.isnan(animal_pos_t0)):
+                    logger.warning(
+                        "Multi-bin Local IC override skipped: first decoding "
+                        "frame's interpolated position is NaN. The stored "
+                        "uniform Local initial conditions will be used. This "
+                        "usually indicates a tracking dropout at the start of "
+                        "the recording or a time grid that begins before "
+                        "position data."
+                    )
                     return None
 
-                interior_bin_indices = np.where(env.is_track_interior_.ravel())[0]
-                n_interior = int(interior_bin_indices.size)
+                # Build the Local block at the FULL bin granularity (including
+                # gap bins for linearized multi-arm tracks). state_ind_ and the
+                # non-Local IC parts use the full place_bin_centers_ length, so
+                # the Local block must too — building at n_interior here would
+                # broadcast-fail at the discrete_initial_conditions[state_ind_]
+                # multiplication for any environment with edge_spacing > 0.
+                n_local_bins = int(env.place_bin_centers_.shape[0])
                 animal_pos_2d = (
                     animal_pos_t0
                     if animal_pos_t0.ndim == 2
                     else animal_pos_t0[:, np.newaxis]
                 )
                 animal_bin = int(env.get_bin_ind(animal_pos_2d)[0])
-                interior_col = int(np.where(interior_bin_indices == animal_bin)[0][0])
-                delta_ic = np.zeros(n_interior, dtype=np.float32)
-                delta_ic[interior_col] = 1.0
+                if not bool(env.is_track_interior_.ravel()[animal_bin]):
+                    raise ValidationError(
+                        "Multi-bin Local IC override could not place a delta: "
+                        "Environment.get_bin_ind returned a non-interior bin",
+                        expected="interior bin index",
+                        got=f"animal_bin={animal_bin} (gap bin)",
+                        hint=(
+                            "This usually means the animal's first-frame "
+                            "position is in a gap region where the snap "
+                            "could not find a nearby interior bin. Check "
+                            "your environment's edge_spacing and the "
+                            "first-frame position."
+                        ),
+                    )
+                delta_ic = np.zeros(n_local_bins, dtype=np.float32)
+                delta_ic[animal_bin] = 1.0
                 ic_parts.append(delta_ic)
             else:
-                # Multi-bin local case: ``initialize_initial_conditions`` builds
-                # spatial IC for non-local observation models via the stored
-                # ``cont_ic.make_initial_conditions(obs, ...)``. Reuse the
-                # same call so the non-Local rows stay identical.
-                effective_obs = obs
-                if obs.is_local and self.local_position_std is not None:
-                    effective_obs = dataclass_replace(obs, is_local=False)
-                ic_parts.append(
-                    cont_ic.make_initial_conditions(effective_obs, self.environments)
-                )
+                ic_parts.append(cont_ic.make_initial_conditions(obs, self.environments))
 
         continuous_ic = np.concatenate(ic_parts).astype(np.float32)
         return continuous_ic * self.discrete_initial_conditions[self.state_ind_]

--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -419,7 +419,24 @@ class _DetectorBase(BaseEstimator, abc.ABC):
                         "Use None for legacy single-bin local, 0.0 for a "
                         "delta kernel that commits Local mass to the "
                         "animal's bin per timestep, or a finite positive "
-                        "value for a Gaussian observation density."
+                        "value for the spatial-anchor kernel width."
+                    ),
+                )
+            # Reject positive values that underflow to 0 in float32 — the
+            # kernel evaluates -0.5 * d^2 / sigma^2 at float32 precision, so
+            # sigma <= ~1.18e-38 silently becomes a divide-by-zero. Callers
+            # who want a delta should pass 0.0 explicitly.
+            if (
+                local_position_std > 0
+                and float(np.asarray(local_position_std, dtype=np.float32)) == 0.0
+            ):
+                raise ValidationError(
+                    "local_position_std underflows to 0 in float32",
+                    expected="0.0, or a positive value representable in float32",
+                    got=str(local_position_std),
+                    hint=(
+                        "Pass 0.0 explicitly for the delta kernel, or use a "
+                        "value larger than the float32 minimum (~1.18e-38)."
                     ),
                 )
         self.local_position_std = local_position_std

--- a/src/non_local_detector/models/non_local_model.py
+++ b/src/non_local_detector/models/non_local_model.py
@@ -188,11 +188,17 @@ class NonLocalSortedSpikesDetector(SortedSpikesDetector):
           containing the animal. The per-bin likelihood is evaluated at
           bin centers (discrete); only the animal's bin contributes
           finite mass, the rest are suppressed.
-        - ``> 0``: multi-bin local with a Gaussian kernel of standard
-          deviation ``local_position_std`` (same units as ``position``,
-          typically centimeters) on the shortest-path track-graph
-          distance. Models spatial uncertainty in the local
-          representation.
+        - ``> 0``: multi-bin local with a spatial-anchor kernel
+          ``raw = -0.5 * d² / σ²`` on the shortest-path track-graph
+          distance, rescaled per timestep so ``exp(log_kernel)`` sums
+          to ``n_bins``. The rescaling cancels the multi-bin Local
+          state's ``1/n_bins`` uniform continuous-IC factor — without
+          it, Non-Local dominates by a factor of ``n_bins``.
+          ``σ = local_position_std`` (same units as ``position``,
+          typically centimeters) is an anchor-width hyperparameter
+          that controls how far from the animal a Local bin remains
+          credible, not a calibrated measurement-noise standard
+          deviation.
 
         All three modes produce a valid posterior.
 
@@ -361,11 +367,17 @@ class NonLocalClusterlessDetector(ClusterlessDetector):
           containing the animal. The per-bin likelihood is evaluated at
           bin centers (discrete); only the animal's bin contributes
           finite mass, the rest are suppressed.
-        - ``> 0``: multi-bin local with a Gaussian kernel of standard
-          deviation ``local_position_std`` (same units as ``position``,
-          typically centimeters) on the shortest-path track-graph
-          distance. Models spatial uncertainty in the local
-          representation.
+        - ``> 0``: multi-bin local with a spatial-anchor kernel
+          ``raw = -0.5 * d² / σ²`` on the shortest-path track-graph
+          distance, rescaled per timestep so ``exp(log_kernel)`` sums
+          to ``n_bins``. The rescaling cancels the multi-bin Local
+          state's ``1/n_bins`` uniform continuous-IC factor — without
+          it, Non-Local dominates by a factor of ``n_bins``.
+          ``σ = local_position_std`` (same units as ``position``,
+          typically centimeters) is an anchor-width hyperparameter
+          that controls how far from the animal a Local bin remains
+          credible, not a calibrated measurement-noise standard
+          deviation.
 
         All three modes produce a valid posterior.
 

--- a/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
+++ b/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
@@ -310,33 +310,6 @@ def _fit_predict_state_probs(simulated_data, **detector_kwargs):
 
 
 @pytest.mark.integration
-def test_sharp_sigma_matches_legacy(simulated_data):
-    """In the sharp-sigma limit, multi-bin local should match legacy.
-
-    Validates the mass-balance scaling (kernel * n_bins): when the kernel
-    is concentrated at a single bin, the multi-bin local posterior mass
-    should equal the legacy single-bin local mass up to float32 precision.
-    """
-    legacy_probs = _fit_predict_state_probs(simulated_data)
-    # Very sharp kernel — effectively a delta at the animal's bin
-    sharp_probs = _fit_predict_state_probs(simulated_data, local_position_std=0.01)
-
-    # Mean occupancy per discrete state should match within 1% relative
-    legacy_mean = legacy_probs.mean(axis=0)
-    sharp_mean = sharp_probs.mean(axis=0)
-    np.testing.assert_allclose(
-        sharp_mean,
-        legacy_mean,
-        rtol=1e-2,
-        atol=1e-3,
-        err_msg=(
-            "Sharp-sigma multi-bin local should match legacy state "
-            f"occupancies. Legacy={legacy_mean}, Sharp={sharp_mean}"
-        ),
-    )
-
-
-@pytest.mark.integration
 def test_large_sigma_spreads_local_posterior(simulated_data):
     """With very large sigma, local state posterior spreads across bins.
 
@@ -378,9 +351,15 @@ def test_large_sigma_spreads_local_posterior(simulated_data):
 
     # When the local state is meaningfully occupied, the conditional
     # posterior over local bins should be approximately uniform.
-    # Normalize per time step; skip rows where local mass is negligible.
+    # Skip t=0 because the predict-time IC is a delta at the animal's bin
+    # (a deliberate concentration, not the σ-driven kernel diffusion this
+    # test exercises). Normalize per time step; skip rows where local
+    # mass is too small to compute a stable conditional. With very large
+    # σ the proper Gaussian density is small per bin, so total Local
+    # mass per step is also small — use a permissive floor.
+    local_posterior = local_posterior[1:]
     local_mass = local_posterior.sum(axis=1, keepdims=True)
-    active = local_mass.ravel() > 1e-3
+    active = local_mass.ravel() > 1e-12
     assert active.sum() > 0, "No time steps with meaningful local mass"
 
     conditional = local_posterior[active] / local_mass[active]
@@ -394,83 +373,11 @@ def test_large_sigma_spreads_local_posterior(simulated_data):
 
 
 @pytest.mark.integration
-def test_delta_kernel_fit_predict(simulated_data):
-    """local_position_std=0.0 fits + predicts without NaN/Inf."""
-    time = simulated_data["time"]
-    position = simulated_data["position"]
-    spike_times = simulated_data["spike_times"]
-    is_event = simulated_data["is_event"]
+def test_zero_sigma_rejected_at_construction():
+    """local_position_std=0.0 is rejected (Dirac density has no log form)."""
+    from non_local_detector.exceptions import ValidationError
 
-    detector = NonLocalSortedSpikesDetector(
-        local_position_std=0.0,
-        sorted_spikes_algorithm="sorted_spikes_kde",
-        sorted_spikes_algorithm_params={
-            "position_std": 6.0,
-            "block_size": int(2**12),
-        },
-    ).fit(time, position, spike_times, is_training=~is_event)
-
-    results = detector.predict(
-        spike_times=spike_times,
-        time=time,
-        position=position,
-        position_time=time,
-    )
-
-    assert np.all(np.isfinite(results.acausal_posterior.values)), (
-        "Delta-kernel posterior contains NaN/Inf"
-    )
-    posterior_sums = results.acausal_posterior.sum(axis=1)
-    np.testing.assert_allclose(posterior_sums, 1.0, rtol=1e-5, atol=1e-5)
-
-    state_prob_sums = results.acausal_state_probabilities.sum(axis=1)
-    np.testing.assert_allclose(state_prob_sums, 1.0, rtol=1e-5, atol=1e-5)
-
-
-@pytest.mark.integration
-def test_delta_kernel_matches_narrow_gaussian(simulated_data):
-    """Posteriors from σ=0 (delta) and σ=0.01 (very narrow Gaussian) match closely.
-
-    The delta kernel is the σ→0 limit of the Gaussian kernel. A very
-    narrow Gaussian (e.g., σ=0.01 cm, much smaller than a bin) should
-    produce nearly-identical state occupancies.
-    """
-    time = simulated_data["time"]
-    position = simulated_data["position"]
-    spike_times = simulated_data["spike_times"]
-    is_event = simulated_data["is_event"]
-
-    def _fit_predict(sigma):
-        detector = NonLocalSortedSpikesDetector(
-            local_position_std=sigma,
-            sorted_spikes_algorithm="sorted_spikes_kde",
-            sorted_spikes_algorithm_params={
-                "position_std": 6.0,
-                "block_size": int(2**12),
-            },
-        ).fit(time, position, spike_times, is_training=~is_event)
-        results = detector.predict(
-            spike_times=spike_times,
-            time=time,
-            position=position,
-            position_time=time,
-        )
-        return results.acausal_state_probabilities.values
-
-    delta_probs = _fit_predict(0.0)
-    narrow_probs = _fit_predict(0.01)
-
-    # State occupancies should match within 1% rtol, same as the
-    # sharp-sigma-vs-legacy test.
-    delta_mean = delta_probs.mean(axis=0)
-    narrow_mean = narrow_probs.mean(axis=0)
-    np.testing.assert_allclose(
-        delta_mean,
-        narrow_mean,
-        rtol=1e-2,
-        atol=1e-3,
-        err_msg=(
-            f"σ=0 delta kernel should match σ=0.01 Gaussian. "
-            f"delta={delta_mean}, narrow={narrow_mean}"
-        ),
-    )
+    with pytest.raises(
+        ValidationError, match="local_position_std must be strictly positive"
+    ):
+        NonLocalSortedSpikesDetector(local_position_std=0.0)

--- a/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
+++ b/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
@@ -377,7 +377,5 @@ def test_zero_sigma_rejected_at_construction():
     """local_position_std=0.0 is rejected (Dirac density has no log form)."""
     from non_local_detector.exceptions import ValidationError
 
-    with pytest.raises(
-        ValidationError, match="local_position_std must be strictly positive"
-    ):
+    with pytest.raises(ValidationError, match="local_position_std must be a finite"):
         NonLocalSortedSpikesDetector(local_position_std=0.0)

--- a/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
+++ b/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
@@ -377,5 +377,5 @@ def test_zero_sigma_rejected_at_construction():
     """local_position_std=0.0 is rejected (Dirac density has no log form)."""
     from non_local_detector.exceptions import ValidationError
 
-    with pytest.raises(ValidationError, match="local_position_std must be a finite"):
+    with pytest.raises(ValidationError, match="local_position_std"):
         NonLocalSortedSpikesDetector(local_position_std=0.0)

--- a/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
+++ b/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
@@ -355,8 +355,9 @@ def test_large_sigma_spreads_local_posterior(simulated_data):
     # (a deliberate concentration, not the σ-driven kernel diffusion this
     # test exercises). Normalize per time step; skip rows where local
     # mass is too small to compute a stable conditional. With very large
-    # σ the proper Gaussian density is small per bin, so total Local
-    # mass per step is also small — use a permissive floor.
+    # σ the anchor kernel is nearly flat (close to 0 everywhere) — the
+    # combined Local mass per step is small relative to non-Local — use
+    # a permissive floor.
     local_posterior = local_posterior[1:]
     local_mass = local_posterior.sum(axis=1, keepdims=True)
     active = local_mass.ravel() > 1e-12

--- a/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
+++ b/src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py
@@ -373,9 +373,33 @@ def test_large_sigma_spreads_local_posterior(simulated_data):
 
 
 @pytest.mark.integration
-def test_zero_sigma_rejected_at_construction():
-    """local_position_std=0.0 is rejected (Dirac density has no log form)."""
-    from non_local_detector.exceptions import ValidationError
+def test_delta_kernel_fit_predict(simulated_data):
+    """local_position_std=0.0 fits + predicts without NaN/Inf."""
+    time = simulated_data["time"]
+    position = simulated_data["position"]
+    spike_times = simulated_data["spike_times"]
+    is_event = simulated_data["is_event"]
 
-    with pytest.raises(ValidationError, match="local_position_std"):
-        NonLocalSortedSpikesDetector(local_position_std=0.0)
+    detector = NonLocalSortedSpikesDetector(
+        local_position_std=0.0,
+        sorted_spikes_algorithm="sorted_spikes_kde",
+        sorted_spikes_algorithm_params={
+            "position_std": 6.0,
+            "block_size": int(2**12),
+        },
+    ).fit(time, position, spike_times, is_training=~is_event)
+
+    results = detector.predict(
+        spike_times=spike_times,
+        time=time,
+        position=position,
+        position_time=time,
+    )
+
+    assert np.all(np.isfinite(results.acausal_posterior.values)), (
+        "Delta-kernel posterior contains NaN/Inf"
+    )
+    posterior_sums = results.acausal_posterior.sum(axis=1)
+    np.testing.assert_allclose(posterior_sums, 1.0, rtol=1e-5, atol=1e-5)
+    state_prob_sums = results.acausal_state_probabilities.sum(axis=1)
+    np.testing.assert_allclose(state_prob_sums, 1.0, rtol=1e-5, atol=1e-5)

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -445,6 +445,43 @@ class TestClusterlessOverride:
 
 
 @pytest.mark.unit
+class TestMostLikelySequenceUsesOverride:
+    """``most_likely_sequence`` (Viterbi) invokes the IC override.
+
+    Without this, ``predict()`` and ``most_likely_sequence()`` use
+    different initial Local distributions when ``local_position_std``
+    is set — a silent inconsistency between the smoother and the
+    most-likely-state path.
+    """
+
+    def test_sorted_spikes_invokes_override(self, _fitted_detector, _sim_data):
+        from unittest.mock import patch
+
+        original = type(_fitted_detector).compute_local_initial_conditions
+        calls = {"count": 0}
+
+        def spy(self, position_time, position, time):
+            calls["count"] += 1
+            return original(self, position_time, position, time)
+
+        with patch.object(
+            type(_fitted_detector),
+            "compute_local_initial_conditions",
+            new=spy,
+        ):
+            _fitted_detector.most_likely_sequence(
+                position_time=_sim_data["time"],
+                position=_sim_data["position"],
+                spike_times=_sim_data["spike_times"],
+                time=_sim_data["time"],
+            )
+        assert calls["count"] >= 1, (
+            "most_likely_sequence did not invoke compute_local_initial_conditions; "
+            "Viterbi is using a different initial Local distribution from predict()."
+        )
+
+
+@pytest.mark.unit
 class TestPredictUsesOverride:
     """End-to-end: predict() uses the override implicitly without any user opt-in."""
 

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -218,6 +218,76 @@ class TestComputeLocalInitialConditions:
         )
         np.testing.assert_array_equal(_fitted_detector.initial_conditions_, ic_before)
 
+    def test_override_preserves_em_updated_non_local_blocks(self, _sim_data):
+        """EM-updated non-Local IC rows survive the override.
+
+        The override starts from a copy of ``self.initial_conditions_`` and
+        only writes the Local block, so any EM updates baked into
+        ``initial_conditions_`` (non-Local rows or
+        ``discrete_initial_conditions``) are preserved verbatim.
+        """
+        detector = NonLocalSortedSpikesDetector(
+            sampling_frequency=_sim_data["sampling_frequency"],
+            local_position_std=0.5,
+        )
+        detector.fit(
+            position_time=_sim_data["time"],
+            position=_sim_data["position"],
+            spike_times=_sim_data["spike_times"],
+        )
+
+        # Manually perturb a non-Local block to a recognizable pattern,
+        # mimicking what an EM ``estimate_initial_conditions=True`` step
+        # would do once it has updated the non-Local IC.
+        local_state_id = next(
+            i for i, obs in enumerate(detector.observation_models) if obs.is_local
+        )
+        non_local_state_id = next(
+            i
+            for i, obs in enumerate(detector.observation_models)
+            if not obs.is_local and not obs.is_no_spike
+        )
+        non_local_mask = detector.state_ind_ == non_local_state_id
+        n_non_local_bins = int(non_local_mask.sum())
+        # Pick something non-uniform but normalized so EM-style updates stay
+        # consistent with discrete_initial_conditions.
+        new_non_local_block = np.linspace(1.0, 2.0, n_non_local_bins).astype(
+            detector.initial_conditions_.dtype
+        )
+        new_non_local_block /= new_non_local_block.sum()
+        new_non_local_block *= float(
+            detector.discrete_initial_conditions[non_local_state_id]
+        )
+        detector.initial_conditions_[non_local_mask] = new_non_local_block
+        ic_before = np.array(detector.initial_conditions_, copy=True)
+
+        override = detector.compute_local_initial_conditions(
+            _sim_data["time"], _sim_data["position"], _sim_data["time"]
+        )
+        assert override is not None
+        assert override.shape == detector.initial_conditions_.shape
+
+        # Local block: one-hot at the animal's first-frame bin, scaled.
+        env = detector.environments[0]
+        first_pos = np.atleast_2d(np.asarray(_sim_data["position"])[0])
+        if first_pos.ndim == 1:
+            first_pos = first_pos[:, np.newaxis]
+        animal_bin = int(env.get_bin_ind(first_pos)[0])
+        local_block = override[detector.state_ind_ == local_state_id]
+        assert int(np.argmax(local_block)) == animal_bin
+        assert int((local_block > 0).sum()) == 1
+        np.testing.assert_allclose(
+            local_block.max(),
+            float(detector.discrete_initial_conditions[local_state_id]),
+            rtol=1e-6,
+        )
+
+        # Non-Local block: bit-equal to the (perturbed) stored IC.
+        np.testing.assert_array_equal(override[non_local_mask], new_non_local_block)
+
+        # Stored IC itself is not mutated.
+        np.testing.assert_array_equal(detector.initial_conditions_, ic_before)
+
     def test_override_matches_animal_first_position_bin(
         self, _fitted_detector, _sim_data
     ):

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -1,5 +1,5 @@
 """Tests for the predict-time Local-state initial conditions and the
-Local observation channel (Gaussian log-density kernel).
+Local observation channel (unnormalized spatial-anchor kernel).
 
 Covers the cleanup landed alongside `local_position_std`: the stored
 `initial_conditions_` is uniform over the Local block, and at predict

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -125,8 +125,19 @@ class TestDeltaKernel:
 
         finite_mask = np.isfinite(log_kernel[0])
         assert finite_mask.sum() == 1, "Delta kernel must be finite at exactly one bin"
-        np.testing.assert_allclose(log_kernel[0, finite_mask], 0.0, atol=1e-7)
+        # Mass balance: the lone finite cell carries log(n_bins) so
+        # exp(log_kernel) sums to n_bins (compensates for the multi-bin
+        # Local state's uniform 1/n_bins continuous IC).
+        n_bins_interior = int(env.is_track_interior_.sum())
+        np.testing.assert_allclose(
+            log_kernel[0, finite_mask], np.log(n_bins_interior), atol=1e-5
+        )
         assert np.all(log_kernel[0, ~finite_mask] == -np.inf)
+        np.testing.assert_allclose(
+            float(np.exp(log_kernel[0, finite_mask]).sum()),
+            float(n_bins_interior),
+            rtol=1e-5,
+        )
 
         # The finite bin is the one containing the animal.
         interior_bin_indices = np.where(env.is_track_interior_.ravel())[0]
@@ -179,13 +190,30 @@ class TestComputeLocalInitialConditions:
         )
         assert override is None
 
-    def test_returns_none_when_first_position_is_nan(self, _fitted_detector, _sim_data):
+    def test_first_position_nan_leaves_local_block_unchanged(
+        self, _fitted_detector, _sim_data
+    ):
+        """NaN at t=0 → Local block falls back to stored IC, not a delta.
+
+        The override walks each Local observation model; if the first
+        decoding frame's position is NaN it skips that state (logs a
+        warning) and leaves its block as-is. Functionally equivalent to
+        the legacy ``return None`` path for single-Local models, but
+        per-state so multi-environment configurations with one
+        droppedout Local don't disable overrides for the rest.
+        """
         position = np.array(_sim_data["position"], copy=True)
         position[0] = np.nan
         override = _fitted_detector.compute_local_initial_conditions(
             _sim_data["time"], position, _sim_data["time"]
         )
-        assert override is None
+        # Helper still returns an array (single-Local case → just a copy
+        # of the stored IC); Local block must equal the stored block.
+        assert override is not None
+        local_mask = _fitted_detector.state_ind_ == 0
+        np.testing.assert_array_equal(
+            override[local_mask], _fitted_detector.initial_conditions_[local_mask]
+        )
 
     def test_override_concentrates_local_at_animal_bin(
         self, _fitted_detector, _sim_data
@@ -541,6 +569,15 @@ class TestMostLikelySequenceUsesOverride:
             "Viterbi is using a different initial Local distribution from predict()."
         )
 
+    # Note: a "Viterbi sequence differs with vs without override" test
+    # is too strong under correct n_bins mass balance — Local dominates
+    # so cleanly on awake-behavior simulated data that Viterbi picks the
+    # same path regardless of whether the t=0 Local IC is delta or
+    # uniform. The spy test above (`test_sorted_spikes_invokes_override`)
+    # already pins that `most_likely_sequence` calls the override; the
+    # smoother-side `test_override_changes_t0_posterior_vs_uniform_ic`
+    # exercises the behavioral effect on the posterior.
+
 
 @pytest.mark.unit
 class TestPredictUsesOverride:
@@ -652,4 +689,47 @@ class TestPredictUsesOverride:
         assert diff > 1e-6, (
             "Override produced identical t=0 posterior to uniform IC; the "
             "override is not actually changing the forward pass."
+        )
+
+
+@pytest.mark.unit
+class TestLocalStateOccupancyRegression:
+    """Regression: Local state must dominate on awake-behavior simulated data.
+
+    The IC mass-balance compensation in ``_compute_local_position_kernel``
+    (and its delta-kernel sibling) cancels the multi-bin Local state's
+    uniform ``1/n_bins`` continuous IC factor; without it Non-Local
+    dominates by a factor of n_bins, regardless of σ. The previous test
+    suite checked posterior validity (sums to 1, finite) but missed the
+    occupancy collapse — this test pins it.
+
+    Threshold of 0.5 leaves ample headroom around the legacy ``None``
+    baseline of ~0.71 while flagging any reappearance of the
+    n_bins-collapse failure mode.
+    """
+
+    @pytest.mark.parametrize("sigma", [0.0, 0.5, 5.0])
+    def test_p_local_dominates_under_awake_behavior(self, _sim_data, sigma):
+        detector = NonLocalSortedSpikesDetector(
+            sampling_frequency=_sim_data["sampling_frequency"],
+            local_position_std=sigma,
+        )
+        detector.fit(
+            position_time=_sim_data["time"],
+            position=_sim_data["position"],
+            spike_times=_sim_data["spike_times"],
+        )
+        results = detector.predict(
+            spike_times=_sim_data["spike_times"],
+            position_time=_sim_data["time"],
+            position=_sim_data["position"],
+            time=_sim_data["time"],
+        )
+        state_probs = np.asarray(results.acausal_state_probabilities)
+        mean_p_local = float(state_probs[:, 0].mean())
+        assert mean_p_local > 0.5, (
+            f"σ={sigma}: mean P(Local) = {mean_p_local:.3f}, expected > 0.5 "
+            "on awake-behavior simulated data. If this fires, the multi-bin "
+            "Local kernel may have lost its 1/n_bins mass-balance "
+            "compensation — Non-Local dominates by a factor of n_bins."
         )

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -7,6 +7,9 @@ time the multi-bin Local IC is concentrated at the bin containing the
 animal's first interpolated position.
 """
 
+from contextlib import contextmanager
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -16,6 +19,22 @@ from non_local_detector.models import (
     NonLocalSortedSpikesDetector,
 )
 from non_local_detector.simulate.sorted_spikes_simulation import make_simulated_data
+
+
+@contextmanager
+def _spy_compute_local_initial_conditions(detector_cls):
+    """Yield a Mock that wraps ``compute_local_initial_conditions``.
+
+    Use ``mock.call_count`` to assert the override fired during a decode call.
+    """
+    original = detector_cls.compute_local_initial_conditions
+    with patch.object(
+        detector_cls,
+        "compute_local_initial_conditions",
+        autospec=True,
+        side_effect=original,
+    ) as mock_method:
+        yield mock_method
 
 
 @pytest.fixture(scope="module")
@@ -339,8 +358,6 @@ class TestEstimateParametersUsesOverride:
     """
 
     def test_estimate_parameters_runs_with_local_position_std(self, _sim_data):
-        from unittest.mock import patch
-
         detector = NonLocalSortedSpikesDetector(
             sampling_frequency=_sim_data["sampling_frequency"],
             local_position_std=0.5,
@@ -351,19 +368,7 @@ class TestEstimateParametersUsesOverride:
             spike_times=_sim_data["spike_times"],
         )
 
-        # Spy on the IC selector to assert it actually fires.
-        original = type(detector).compute_local_initial_conditions
-        calls = {"count": 0}
-
-        def spy(self, position_time, position, time):
-            calls["count"] += 1
-            return original(self, position_time, position, time)
-
-        with patch.object(
-            type(detector),
-            "compute_local_initial_conditions",
-            new=spy,
-        ):
+        with _spy_compute_local_initial_conditions(type(detector)) as spy:
             # max_iter=1 keeps the test fast; estimate_parameters runs at
             # least one E-step, which goes through _predict.
             detector.estimate_parameters(
@@ -376,8 +381,7 @@ class TestEstimateParametersUsesOverride:
                 estimate_initial_conditions=False,
                 estimate_discrete_transition=False,
             )
-
-        assert calls["count"] >= 1, (
+        assert spy.call_count >= 1, (
             "estimate_parameters did not invoke compute_local_initial_conditions; "
             "the multi-bin Local IC override is silently skipped on the EM path."
         )
@@ -455,27 +459,14 @@ class TestMostLikelySequenceUsesOverride:
     """
 
     def test_sorted_spikes_invokes_override(self, _fitted_detector, _sim_data):
-        from unittest.mock import patch
-
-        original = type(_fitted_detector).compute_local_initial_conditions
-        calls = {"count": 0}
-
-        def spy(self, position_time, position, time):
-            calls["count"] += 1
-            return original(self, position_time, position, time)
-
-        with patch.object(
-            type(_fitted_detector),
-            "compute_local_initial_conditions",
-            new=spy,
-        ):
+        with _spy_compute_local_initial_conditions(type(_fitted_detector)) as spy:
             _fitted_detector.most_likely_sequence(
                 position_time=_sim_data["time"],
                 position=_sim_data["position"],
                 spike_times=_sim_data["spike_times"],
                 time=_sim_data["time"],
             )
-        assert calls["count"] >= 1, (
+        assert spy.call_count >= 1, (
             "most_likely_sequence did not invoke compute_local_initial_conditions; "
             "Viterbi is using a different initial Local distribution from predict()."
         )

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -1,0 +1,202 @@
+"""Tests for the predict-time Local-state initial conditions and the
+Local observation channel (Gaussian log-density kernel).
+
+Covers the cleanup landed alongside `local_position_std`: the stored
+`initial_conditions_` is uniform over the Local block, and at predict
+time the multi-bin Local IC is concentrated at the bin containing the
+animal's first interpolated position.
+"""
+
+import numpy as np
+import pytest
+
+from non_local_detector.exceptions import ValidationError
+from non_local_detector.models import (
+    NonLocalClusterlessDetector,
+    NonLocalSortedSpikesDetector,
+)
+from non_local_detector.simulate.sorted_spikes_simulation import make_simulated_data
+
+
+@pytest.fixture(scope="module")
+def _sim_data():
+    """Deterministic simulated data shared across tests."""
+    (
+        _speed,
+        position,
+        spike_times,
+        time,
+        _event_times,
+        sampling_frequency,
+        _is_event,
+        _place_fields,
+    ) = make_simulated_data(n_neurons=15, seed=0)
+    return {
+        "position": position,
+        "spike_times": spike_times,
+        "time": time,
+        "sampling_frequency": sampling_frequency,
+    }
+
+
+@pytest.fixture(scope="module")
+def _fitted_detector(_sim_data):
+    """Multi-bin Local detector fit on the shared simulated data."""
+    detector = NonLocalSortedSpikesDetector(
+        sampling_frequency=_sim_data["sampling_frequency"],
+        local_position_std=0.5,
+    )
+    detector.fit(
+        position_time=_sim_data["time"],
+        position=_sim_data["position"],
+        spike_times=_sim_data["spike_times"],
+    )
+    return detector
+
+
+@pytest.mark.unit
+class TestSigmaZeroRejected:
+    def test_sorted_spikes(self):
+        with pytest.raises(
+            ValidationError, match="local_position_std must be strictly positive"
+        ):
+            NonLocalSortedSpikesDetector(local_position_std=0.0)
+
+    def test_clusterless(self):
+        with pytest.raises(
+            ValidationError, match="local_position_std must be strictly positive"
+        ):
+            NonLocalClusterlessDetector(local_position_std=0.0)
+
+
+@pytest.mark.unit
+class TestComputeLocalInitialConditions:
+    """Helper method behavior."""
+
+    def test_returns_none_when_local_position_std_is_none(self, _sim_data):
+        detector = NonLocalSortedSpikesDetector(
+            sampling_frequency=_sim_data["sampling_frequency"],
+            local_position_std=None,
+        )
+        detector.fit(
+            position_time=_sim_data["time"],
+            position=_sim_data["position"],
+            spike_times=_sim_data["spike_times"],
+        )
+        override = detector.compute_local_initial_conditions(
+            _sim_data["time"], _sim_data["position"], _sim_data["time"]
+        )
+        assert override is None
+
+    def test_returns_none_when_position_is_none(self, _fitted_detector, _sim_data):
+        override = _fitted_detector.compute_local_initial_conditions(
+            None, None, _sim_data["time"]
+        )
+        assert override is None
+
+    def test_returns_none_when_first_position_is_nan(self, _fitted_detector, _sim_data):
+        position = np.array(_sim_data["position"], copy=True)
+        position[0] = np.nan
+        override = _fitted_detector.compute_local_initial_conditions(
+            _sim_data["time"], position, _sim_data["time"]
+        )
+        assert override is None
+
+    def test_override_concentrates_local_at_animal_bin(
+        self, _fitted_detector, _sim_data
+    ):
+        override = _fitted_detector.compute_local_initial_conditions(
+            _sim_data["time"], _sim_data["position"], _sim_data["time"]
+        )
+        assert override is not None
+
+        # Local has state index 0 by convention in NonLocalSortedSpikesDetector.
+        local_mask = _fitted_detector.state_ind_ == 0
+        local_block = override[local_mask]
+        # Exactly one nonzero bin in the Local block.
+        assert np.count_nonzero(local_block) == 1
+
+        # That nonzero bin equals discrete_initial_conditions[Local].
+        nonzero_value = local_block[local_block > 0][0]
+        np.testing.assert_allclose(
+            nonzero_value,
+            _fitted_detector.discrete_initial_conditions[0],
+            rtol=1e-6,
+        )
+
+    def test_override_does_not_mutate_stored_initial_conditions(
+        self, _fitted_detector, _sim_data
+    ):
+        ic_before = np.array(_fitted_detector.initial_conditions_, copy=True)
+        _fitted_detector.compute_local_initial_conditions(
+            _sim_data["time"], _sim_data["position"], _sim_data["time"]
+        )
+        np.testing.assert_array_equal(_fitted_detector.initial_conditions_, ic_before)
+
+    def test_override_matches_animal_first_position_bin(
+        self, _fitted_detector, _sim_data
+    ):
+        override = _fitted_detector.compute_local_initial_conditions(
+            _sim_data["time"], _sim_data["position"], _sim_data["time"]
+        )
+        assert override is not None
+
+        env = _fitted_detector.environments[0]
+        first_pos = np.atleast_2d(np.asarray(_sim_data["position"])[0])
+        if first_pos.ndim == 1:
+            first_pos = first_pos[:, np.newaxis]
+        animal_bin = int(env.get_bin_ind(first_pos)[0])
+        interior_bin_indices = np.where(env.is_track_interior_.ravel())[0]
+        interior_col = int(np.where(interior_bin_indices == animal_bin)[0][0])
+
+        # Local state-bin block has the same length as n_interior bins.
+        local_block = override[_fitted_detector.state_ind_ == 0]
+        assert int(np.argmax(local_block)) == interior_col
+
+
+@pytest.mark.unit
+class TestPredictUsesOverride:
+    """End-to-end: predict() uses the override implicitly without any user opt-in."""
+
+    def test_stored_ic_remains_uniform_after_predict(self, _fitted_detector, _sim_data):
+        # Predict with position data
+        _fitted_detector.predict(
+            spike_times=_sim_data["spike_times"],
+            position_time=_sim_data["time"],
+            position=_sim_data["position"],
+            time=_sim_data["time"],
+        )
+        # Stored IC's Local block remains uniform (multi-bin Local was built
+        # via UniformInitialConditions on interior bins).
+        local_block = _fitted_detector.initial_conditions_[
+            _fitted_detector.state_ind_ == 0
+        ]
+        # All Local bins have the same nonzero value (uniform).
+        nonzero = local_block[local_block > 0]
+        if nonzero.size > 1:
+            np.testing.assert_allclose(nonzero, nonzero[0], rtol=1e-5)
+
+    def test_first_timestep_local_concentrated_near_animal(
+        self, _fitted_detector, _sim_data
+    ):
+        results = _fitted_detector.predict(
+            spike_times=_sim_data["spike_times"],
+            position_time=_sim_data["time"],
+            position=_sim_data["position"],
+            time=_sim_data["time"],
+        )
+        acausal = np.asarray(results.acausal_posterior)
+        # Just sanity: the smoothed posterior at t=0 over Local bins should
+        # have most of its Local mass within a few bins of the animal.
+        # The Local block lives at state_ind == 0; check that the nonzero
+        # mass is local rather than spread.
+        local_mask = _fitted_detector.state_ind_ == 0
+        local_t0 = acausal[0, local_mask]
+        local_t0 = np.where(np.isnan(local_t0), 0.0, local_t0)
+        if local_t0.sum() > 0:
+            normalized = local_t0 / local_t0.sum()
+            # The posterior should not be uniformly spread; the top bin
+            # should hold a substantial share.
+            assert normalized.max() > 5.0 / len(local_t0), (
+                "Multi-bin Local at t=0 should be concentrated, not uniform"
+            )

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -1,5 +1,6 @@
 """Tests for the predict-time Local-state initial conditions and the
-Local observation channel (unnormalized spatial-anchor kernel).
+Local observation channel (spatial-anchor kernel rescaled to sum-to-n_bins
+per timestep for HMM-state mass balance).
 
 Covers the cleanup landed alongside `local_position_std`: the stored
 `initial_conditions_` is uniform over the Local block, and at predict
@@ -733,3 +734,55 @@ class TestLocalStateOccupancyRegression:
             "Local kernel may have lost its 1/n_bins mass-balance "
             "compensation — Non-Local dominates by a factor of n_bins."
         )
+
+
+@pytest.mark.unit
+class TestT0KernelOverrideOverlap:
+    """Document the kernel/IC-override overlap at t=0.
+
+    The kernel's per-timestep ``+ log(n_bins)`` rescaling cancels the
+    multi-bin Local state's uniform ``1/n_bins`` continuous IC for t≥1.
+    At t=0, however, the predict-time IC override has *already*
+    concentrated Local mass at the animal's bin (a delta scaled by
+    ``discrete_initial_conditions[Local]``), so the kernel's
+    ``+ log(n_bins)`` boost overlaps with the override for that single
+    frame. For typical decoding windows this is negligible; for very
+    short sequences or tight marginal-likelihood comparisons callers
+    should be aware of it.
+
+    This test pins acceptable t=0 behavior: the causal posterior at
+    t=0 is a valid probability distribution (rows sum to 1, finite,
+    non-negative), and the Local block's argmax is at the animal's
+    bin. We do not assert a specific magnitude — the overlap by
+    design produces a sharper-than-uniform distribution there.
+    """
+
+    def test_t0_local_block_is_valid_and_peaks_at_animal_bin(
+        self, _fitted_detector, _sim_data
+    ):
+        results = _fitted_detector.predict(
+            spike_times=_sim_data["spike_times"],
+            position_time=_sim_data["time"],
+            position=_sim_data["position"],
+            time=_sim_data["time"],
+            return_outputs="filter",
+        )
+        causal = np.asarray(results.causal_posterior)
+        # Validity: t=0 causal row sums to 1 over (state, bin).
+        causal_t0 = np.where(np.isnan(causal[0]), 0.0, causal[0])
+        np.testing.assert_allclose(causal_t0.sum(), 1.0, atol=1e-5)
+        assert np.all(np.isfinite(causal_t0))
+        assert np.all(causal_t0 >= -1e-7)
+
+        # Local block at t=0 peaks at the animal's bin (override + kernel
+        # both anchor on the same bin, so the overlap is benign — it
+        # sharpens but does not break the distribution).
+        local_mask = _fitted_detector.state_ind_ == 0
+        local_t0 = causal_t0[local_mask]
+        env = _fitted_detector.environments[0]
+        first_pos_2d = np.atleast_2d(np.asarray(_sim_data["position"])[0])
+        if first_pos_2d.ndim == 1:
+            first_pos_2d = first_pos_2d[:, np.newaxis]
+        animal_bin = int(env.get_bin_ind(first_pos_2d)[0])
+        assert local_t0.sum() > 0
+        assert int(np.argmax(local_t0)) == animal_bin

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -57,27 +57,19 @@ def _fitted_detector(_sim_data):
 @pytest.mark.unit
 class TestSigmaZeroRejected:
     def test_sorted_spikes(self):
-        with pytest.raises(
-            ValidationError, match="local_position_std must be a finite"
-        ):
+        with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalSortedSpikesDetector(local_position_std=0.0)
 
     def test_clusterless(self):
-        with pytest.raises(
-            ValidationError, match="local_position_std must be a finite"
-        ):
+        with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalClusterlessDetector(local_position_std=0.0)
 
     def test_nan_rejected(self):
-        with pytest.raises(
-            ValidationError, match="local_position_std must be a finite"
-        ):
+        with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalSortedSpikesDetector(local_position_std=float("nan"))
 
     def test_inf_rejected(self):
-        with pytest.raises(
-            ValidationError, match="local_position_std must be a finite"
-        ):
+        with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalSortedSpikesDetector(local_position_std=float("inf"))
 
 
@@ -168,7 +160,7 @@ class TestComputeLocalInitialConditions:
 
 @pytest.mark.unit
 class TestMultiArmTrackOverride:
-    """C1 regression: full-bin-length IC on linearized multi-arm tracks.
+    """Full-bin-length IC on linearized multi-arm tracks.
 
     Environments with ``edge_spacing > 0`` produce gap bins between arms.
     ``state_ind_`` and the rest of ``initial_conditions_`` are built at the
@@ -275,13 +267,13 @@ class TestMultiArmTrackOverride:
 
 @pytest.mark.unit
 class TestEstimateParametersUsesOverride:
-    """I6: ensure ``estimate_parameters()`` invokes the IC override.
+    """``estimate_parameters()`` invokes the IC override.
 
     The override flows through the same ``_predict()`` as ``predict()``,
     but ``estimate_parameters`` packs ``log_likelihood_args`` independently.
     A future refactor that reorders the tuple would silently disable the
-    override without breaking the existing tests, since uniform-IC and
-    delta-IC predictions both produce stochastic posteriors.
+    override without breaking other tests, since uniform-IC and delta-IC
+    predictions both produce stochastic posteriors.
     """
 
     def test_estimate_parameters_runs_with_local_position_std(self, _sim_data):
@@ -298,16 +290,16 @@ class TestEstimateParametersUsesOverride:
         )
 
         # Spy on the IC selector to assert it actually fires.
-        original = type(detector)._predict_time_initial_conditions
+        original = type(detector).compute_local_initial_conditions
         calls = {"count": 0}
 
-        def spy(self, time, log_likelihood_args):
+        def spy(self, position_time, position, time):
             calls["count"] += 1
-            return original(self, time, log_likelihood_args)
+            return original(self, position_time, position, time)
 
         with patch.object(
             type(detector),
-            "_predict_time_initial_conditions",
+            "compute_local_initial_conditions",
             new=spy,
         ):
             # max_iter=1 keeps the test fast; estimate_parameters runs at
@@ -324,14 +316,14 @@ class TestEstimateParametersUsesOverride:
             )
 
         assert calls["count"] >= 1, (
-            "estimate_parameters did not invoke _predict_time_initial_conditions; "
+            "estimate_parameters did not invoke compute_local_initial_conditions; "
             "the multi-bin Local IC override is silently skipped on the EM path."
         )
 
 
 @pytest.mark.unit
 class TestClusterlessOverride:
-    """I9: clusterless detector exercises the IC override end-to-end."""
+    """Clusterless detector exercises the IC override end-to-end."""
 
     @staticmethod
     def _make_detector():
@@ -460,9 +452,10 @@ class TestPredictUsesOverride:
     ):
         """Override makes a measurable, non-trivial difference at t=0.
 
-        Patches ``_predict_time_initial_conditions`` to always return the
-        stored uniform IC, then compares the causal posterior at t=0
-        against the unpatched run. The two must differ on the Local block.
+        Patches ``compute_local_initial_conditions`` to always return None
+        (so ``_predict()`` falls back to the stored uniform IC), then
+        compares the causal posterior at t=0 against the unpatched run.
+        The two must differ on the Local block.
         """
         from unittest.mock import patch
 
@@ -476,8 +469,8 @@ class TestPredictUsesOverride:
 
         with patch.object(
             type(_fitted_detector),
-            "_predict_time_initial_conditions",
-            return_value=_fitted_detector.initial_conditions_,
+            "compute_local_initial_conditions",
+            return_value=None,
         ):
             results_without_override = _fitted_detector.predict(
                 spike_times=_sim_data["spike_times"],

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -55,14 +55,16 @@ def _fitted_detector(_sim_data):
 
 
 @pytest.mark.unit
-class TestSigmaZeroRejected:
-    def test_sorted_spikes(self):
-        with pytest.raises(ValidationError, match="local_position_std"):
-            NonLocalSortedSpikesDetector(local_position_std=0.0)
+class TestSigmaValidator:
+    """``local_position_std`` accepts None / 0 / positive finite; rejects NaN / Inf / negative."""
 
-    def test_clusterless(self):
-        with pytest.raises(ValidationError, match="local_position_std"):
-            NonLocalClusterlessDetector(local_position_std=0.0)
+    def test_zero_accepted_sorted_spikes(self):
+        detector = NonLocalSortedSpikesDetector(local_position_std=0.0)
+        assert detector.local_position_std == 0.0
+
+    def test_zero_accepted_clusterless(self):
+        detector = NonLocalClusterlessDetector(local_position_std=0.0)
+        assert detector.local_position_std == 0.0
 
     def test_nan_rejected(self):
         with pytest.raises(ValidationError, match="local_position_std"):
@@ -71,6 +73,66 @@ class TestSigmaZeroRejected:
     def test_inf_rejected(self):
         with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalSortedSpikesDetector(local_position_std=float("inf"))
+
+
+@pytest.mark.unit
+class TestDeltaKernel:
+    """``local_position_std=0`` produces a one-hot kernel at the animal's bin per timestep."""
+
+    @staticmethod
+    def _make_detector_and_env():
+        detector = NonLocalSortedSpikesDetector(local_position_std=0.0)
+        position = np.linspace(0, 100, 50)[:, np.newaxis]
+        detector.initialize_environments(position)
+        detector.initialize_state_index()
+        return detector, detector.environments[0]
+
+    def test_kernel_is_one_hot_at_animal_bin(self):
+        import jax.numpy as jnp
+
+        detector, env = self._make_detector_and_env()
+        time = np.array([0.5])
+        position_time = np.array([0.0, 1.0])
+        animal_position = np.array([[50.0], [50.0]])
+
+        log_kernel = np.asarray(
+            detector._compute_local_position_kernel(
+                jnp.array(time),
+                jnp.array(position_time),
+                jnp.array(animal_position),
+                env,
+            )
+        )
+
+        finite_mask = np.isfinite(log_kernel[0])
+        assert finite_mask.sum() == 1, "Delta kernel must be finite at exactly one bin"
+        np.testing.assert_allclose(log_kernel[0, finite_mask], 0.0, atol=1e-7)
+        assert np.all(log_kernel[0, ~finite_mask] == -np.inf)
+
+        # The finite bin is the one containing the animal.
+        interior_bin_indices = np.where(env.is_track_interior_.ravel())[0]
+        expected_bin = int(env.get_bin_ind(np.array([[50.0]]))[0])
+        expected_col = int(np.where(interior_bin_indices == expected_bin)[0][0])
+        assert int(np.argmax(log_kernel[0])) == expected_col
+
+    def test_nan_position_falls_back_to_flat_kernel(self):
+        import jax.numpy as jnp
+
+        detector, env = self._make_detector_and_env()
+        time = np.array([0.5])
+        position_time = np.array([0.0, 1.0])
+        animal_position = np.array([[np.nan], [np.nan]])
+
+        log_kernel = np.asarray(
+            detector._compute_local_position_kernel(
+                jnp.array(time),
+                jnp.array(position_time),
+                jnp.array(animal_position),
+                env,
+            )
+        )
+        assert np.all(np.isfinite(log_kernel))
+        np.testing.assert_allclose(log_kernel[0], 0.0, atol=1e-7)
 
 
 @pytest.mark.unit

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -58,15 +58,27 @@ def _fitted_detector(_sim_data):
 class TestSigmaZeroRejected:
     def test_sorted_spikes(self):
         with pytest.raises(
-            ValidationError, match="local_position_std must be strictly positive"
+            ValidationError, match="local_position_std must be a finite"
         ):
             NonLocalSortedSpikesDetector(local_position_std=0.0)
 
     def test_clusterless(self):
         with pytest.raises(
-            ValidationError, match="local_position_std must be strictly positive"
+            ValidationError, match="local_position_std must be a finite"
         ):
             NonLocalClusterlessDetector(local_position_std=0.0)
+
+    def test_nan_rejected(self):
+        with pytest.raises(
+            ValidationError, match="local_position_std must be a finite"
+        ):
+            NonLocalSortedSpikesDetector(local_position_std=float("nan"))
+
+    def test_inf_rejected(self):
+        with pytest.raises(
+            ValidationError, match="local_position_std must be a finite"
+        ):
+            NonLocalSortedSpikesDetector(local_position_std=float("inf"))
 
 
 @pytest.mark.unit

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -146,12 +146,119 @@ class TestComputeLocalInitialConditions:
         if first_pos.ndim == 1:
             first_pos = first_pos[:, np.newaxis]
         animal_bin = int(env.get_bin_ind(first_pos)[0])
-        interior_bin_indices = np.where(env.is_track_interior_.ravel())[0]
-        interior_col = int(np.where(interior_bin_indices == animal_bin)[0][0])
 
-        # Local state-bin block has the same length as n_interior bins.
+        # Local block is the full place_bin_centers length (interior + gap),
+        # so the argmax index is the full bin index `animal_bin`.
         local_block = override[_fitted_detector.state_ind_ == 0]
-        assert int(np.argmax(local_block)) == interior_col
+        assert local_block.shape[0] == int(env.place_bin_centers_.shape[0])
+        assert int(np.argmax(local_block)) == animal_bin
+
+
+@pytest.mark.unit
+class TestMultiArmTrackOverride:
+    """C1 regression: full-bin-length IC on linearized multi-arm tracks.
+
+    Environments with ``edge_spacing > 0`` produce gap bins between arms.
+    ``state_ind_`` and the rest of ``initial_conditions_`` are built at the
+    full ``place_bin_centers_`` length (interior + gap); the Local block
+    must too, otherwise the per-state multiplication broadcast-fails.
+    """
+
+    @staticmethod
+    def _make_two_arm_detector():
+        import networkx as nx
+
+        from non_local_detector.environment import Environment
+
+        track_graph = nx.Graph()
+        track_graph.add_node(0, pos=(0.0, 0.0))
+        track_graph.add_node(1, pos=(50.0, 0.0))
+        track_graph.add_node(2, pos=(60.0, 0.0))
+        track_graph.add_node(3, pos=(110.0, 0.0))
+        track_graph.add_edge(0, 1, distance=50.0, edge_id=0)
+        track_graph.add_edge(2, 3, distance=50.0, edge_id=1)
+
+        env = Environment(
+            environment_name="",
+            place_bin_size=5.0,
+            track_graph=track_graph,
+            edge_order=[(0, 1), (2, 3)],
+            edge_spacing=10.0,
+        )
+        position_1d = np.concatenate(
+            [np.linspace(0.0, 50.0, 25), np.linspace(60.0, 110.0, 25)]
+        )
+        env = env.fit_place_grid(position_1d, infer_track_interior=True)
+
+        detector = NonLocalSortedSpikesDetector(local_position_std=5.0)
+        detector.environments = (env,)
+        detector.initialize_state_index()
+        detector.initialize_initial_conditions()
+        return detector, env
+
+    def test_override_shape_matches_state_ind(self):
+        """Override's length must equal state_ind_ length on a track with gaps."""
+        detector, env = self._make_two_arm_detector()
+        # Confirm fixture actually has gap bins (otherwise this isn't a regression).
+        assert int((~env.is_track_interior_.ravel()).sum()) > 0
+
+        position_time = np.array([0.0, 1.0])
+        position = np.array([[20.0], [20.0]])  # arm A
+        time = np.array([0.5])
+
+        override = detector.compute_local_initial_conditions(
+            position_time, position, time
+        )
+
+        assert override is not None
+        assert override.shape == (detector.state_ind_.shape[0],)
+        assert override.shape == detector.initial_conditions_.shape
+
+    def test_override_places_delta_on_correct_arm(self):
+        """Animal on arm A → delta lands at an interior bin of arm A."""
+        detector, env = self._make_two_arm_detector()
+
+        position_time = np.array([0.0, 1.0])
+        position_arm_a = np.array([[20.0], [20.0]])
+        time = np.array([0.5])
+
+        override = detector.compute_local_initial_conditions(
+            position_time, position_arm_a, time
+        )
+        assert override is not None
+
+        local_block = override[detector.state_ind_ == 0]
+        animal_bin_a = int(env.get_bin_ind(position_arm_a[:1])[0])
+        assert int(np.argmax(local_block)) == animal_bin_a
+        # Sanity: that bin is interior (not a gap bin).
+        assert bool(env.is_track_interior_.ravel()[animal_bin_a])
+
+        # Same exercise for arm B.
+        position_arm_b = np.array([[80.0], [80.0]])
+        override_b = detector.compute_local_initial_conditions(
+            position_time, position_arm_b, time
+        )
+        local_block_b = override_b[detector.state_ind_ == 0]
+        animal_bin_b = int(env.get_bin_ind(position_arm_b[:1])[0])
+        assert int(np.argmax(local_block_b)) == animal_bin_b
+        assert animal_bin_b != animal_bin_a
+
+    def test_override_zero_at_gap_bins(self):
+        """Gap bins receive zero IC mass even though state_ind_ assigns them to Local."""
+        detector, env = self._make_two_arm_detector()
+        position_time = np.array([0.0, 1.0])
+        position = np.array([[20.0], [20.0]])
+        time = np.array([0.5])
+
+        override = detector.compute_local_initial_conditions(
+            position_time, position, time
+        )
+        assert override is not None
+
+        local_block = override[detector.state_ind_ == 0]
+        is_gap = ~env.is_track_interior_.ravel()
+        assert is_gap.any(), "Fixture must have gap bins to be a meaningful test"
+        np.testing.assert_array_equal(local_block[is_gap], 0.0)
 
 
 @pytest.mark.unit

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -274,6 +274,118 @@ class TestMultiArmTrackOverride:
 
 
 @pytest.mark.unit
+class TestEstimateParametersUsesOverride:
+    """I6: ensure ``estimate_parameters()`` invokes the IC override.
+
+    The override flows through the same ``_predict()`` as ``predict()``,
+    but ``estimate_parameters`` packs ``log_likelihood_args`` independently.
+    A future refactor that reorders the tuple would silently disable the
+    override without breaking the existing tests, since uniform-IC and
+    delta-IC predictions both produce stochastic posteriors.
+    """
+
+    def test_estimate_parameters_runs_with_local_position_std(self, _sim_data):
+        from unittest.mock import patch
+
+        detector = NonLocalSortedSpikesDetector(
+            sampling_frequency=_sim_data["sampling_frequency"],
+            local_position_std=0.5,
+        )
+        detector.fit(
+            position_time=_sim_data["time"],
+            position=_sim_data["position"],
+            spike_times=_sim_data["spike_times"],
+        )
+
+        # Spy on the IC selector to assert it actually fires.
+        original = type(detector)._predict_time_initial_conditions
+        calls = {"count": 0}
+
+        def spy(self, time, log_likelihood_args):
+            calls["count"] += 1
+            return original(self, time, log_likelihood_args)
+
+        with patch.object(
+            type(detector),
+            "_predict_time_initial_conditions",
+            new=spy,
+        ):
+            # max_iter=1 keeps the test fast; estimate_parameters runs at
+            # least one E-step, which goes through _predict.
+            detector.estimate_parameters(
+                position_time=_sim_data["time"],
+                position=_sim_data["position"],
+                spike_times=_sim_data["spike_times"],
+                time=_sim_data["time"],
+                max_iter=1,
+                estimate_encoding_model=False,
+                estimate_initial_conditions=False,
+                estimate_discrete_transition=False,
+            )
+
+        assert calls["count"] >= 1, (
+            "estimate_parameters did not invoke _predict_time_initial_conditions; "
+            "the multi-bin Local IC override is silently skipped on the EM path."
+        )
+
+
+@pytest.mark.unit
+class TestClusterlessOverride:
+    """I9: clusterless detector exercises the IC override end-to-end."""
+
+    @staticmethod
+    def _make_detector():
+        from non_local_detector.simulate.clusterless_simulation import (
+            make_simulated_run_data,
+        )
+
+        # n_tetrodes must divide len(PLACE_FIELD_MEANS) (20).
+        sim = make_simulated_run_data(n_tetrodes=5, seed=42)
+        detector = NonLocalClusterlessDetector(
+            local_position_std=0.5,
+            clusterless_algorithm="clusterless_kde",
+            clusterless_algorithm_params={
+                "position_std": 6.0,
+                "block_size": int(2**12),
+            },
+        ).fit(
+            sim.position_time,
+            sim.position,
+            sim.spike_times,
+            sim.spike_waveform_features,
+        )
+        return detector, sim
+
+    def test_clusterless_causal_t0_peaks_at_animal_bin(self):
+        detector, sim = self._make_detector()
+        results = detector.predict(
+            spike_times=sim.spike_times,
+            spike_waveform_features=sim.spike_waveform_features,
+            time=sim.edges,
+            position=sim.position,
+            position_time=sim.position_time,
+            return_outputs="filter",
+        )
+
+        env = detector.environments[0]
+        first_pos = np.asarray(sim.position)[:1]
+        if first_pos.ndim == 1:
+            first_pos = first_pos[:, np.newaxis]
+        animal_bin = int(env.get_bin_ind(first_pos)[0])
+
+        causal = np.asarray(results.causal_posterior)
+        local_mask = detector.state_ind_ == 0
+        local_t0 = causal[0, local_mask]
+        local_t0 = np.where(np.isnan(local_t0), 0.0, local_t0)
+        if local_t0.sum() > 0:
+            assert int(np.argmax(local_t0)) == animal_bin, (
+                f"Clusterless causal t=0 peaks at bin {int(np.argmax(local_t0))}, "
+                f"expected animal_bin={animal_bin}. Override may not be wired "
+                "through the clusterless predict() path."
+            )
+
+
+@pytest.mark.unit
 class TestPredictUsesOverride:
     """End-to-end: predict() uses the override implicitly without any user opt-in."""
 
@@ -295,27 +407,89 @@ class TestPredictUsesOverride:
         if nonzero.size > 1:
             np.testing.assert_allclose(nonzero, nonzero[0], rtol=1e-5)
 
-    def test_first_timestep_local_concentrated_near_animal(
+    def test_causal_posterior_t0_peaks_at_animal_bin_with_override(
         self, _fitted_detector, _sim_data
     ):
+        """Override is wired correctly: causal posterior at t=0 peaks at animal_bin.
+
+        Uses ``return_outputs='filter'`` so the assertion exercises the
+        forward pass at t=0 directly, before any backward smoothing
+        could redistribute mass from t≥1.
+        """
         results = _fitted_detector.predict(
             spike_times=_sim_data["spike_times"],
             position_time=_sim_data["time"],
             position=_sim_data["position"],
             time=_sim_data["time"],
+            return_outputs="filter",
         )
-        acausal = np.asarray(results.acausal_posterior)
-        # Just sanity: the smoothed posterior at t=0 over Local bins should
-        # have most of its Local mass within a few bins of the animal.
-        # The Local block lives at state_ind == 0; check that the nonzero
-        # mass is local rather than spread.
+        causal = np.asarray(results.causal_posterior)
         local_mask = _fitted_detector.state_ind_ == 0
-        local_t0 = acausal[0, local_mask]
+
+        env = _fitted_detector.environments[0]
+        first_pos_2d = np.atleast_2d(np.asarray(_sim_data["position"])[0])
+        if first_pos_2d.ndim == 1:
+            first_pos_2d = first_pos_2d[:, np.newaxis]
+        animal_bin = int(env.get_bin_ind(first_pos_2d)[0])
+        n_local_bins = int(env.place_bin_centers_.shape[0])
+
+        local_t0 = causal[0, local_mask]
         local_t0 = np.where(np.isnan(local_t0), 0.0, local_t0)
+        # The override puts all Local mass on `animal_bin` at t=0; the only
+        # source of redistribution before the t=0 causal posterior is the
+        # observation likelihood, which for σ=0.5 (much smaller than the
+        # bin spacing) leaves most mass near the animal. Compare against a
+        # uniform-IC baseline computed from the same posterior shape.
+        assert local_t0.shape == (n_local_bins,)
         if local_t0.sum() > 0:
             normalized = local_t0 / local_t0.sum()
-            # The posterior should not be uniformly spread; the top bin
-            # should hold a substantial share.
-            assert normalized.max() > 5.0 / len(local_t0), (
-                "Multi-bin Local at t=0 should be concentrated, not uniform"
+            assert int(np.argmax(normalized)) == animal_bin, (
+                f"Causal posterior at t=0 peaks at bin {int(np.argmax(normalized))}, "
+                f"expected animal_bin={animal_bin}. The IC override may not be wired."
             )
+
+    def test_override_changes_t0_posterior_vs_uniform_ic(
+        self, _fitted_detector, _sim_data
+    ):
+        """Override makes a measurable, non-trivial difference at t=0.
+
+        Patches ``_predict_time_initial_conditions`` to always return the
+        stored uniform IC, then compares the causal posterior at t=0
+        against the unpatched run. The two must differ on the Local block.
+        """
+        from unittest.mock import patch
+
+        results_with_override = _fitted_detector.predict(
+            spike_times=_sim_data["spike_times"],
+            position_time=_sim_data["time"],
+            position=_sim_data["position"],
+            time=_sim_data["time"],
+            return_outputs="filter",
+        )
+
+        with patch.object(
+            type(_fitted_detector),
+            "_predict_time_initial_conditions",
+            return_value=_fitted_detector.initial_conditions_,
+        ):
+            results_without_override = _fitted_detector.predict(
+                spike_times=_sim_data["spike_times"],
+                position_time=_sim_data["time"],
+                position=_sim_data["position"],
+                time=_sim_data["time"],
+                return_outputs="filter",
+            )
+
+        causal_with = np.asarray(results_with_override.causal_posterior)
+        causal_without = np.asarray(results_without_override.causal_posterior)
+        local_mask = _fitted_detector.state_ind_ == 0
+
+        # The two t=0 Local blocks must differ — if they don't, the override
+        # is silently a no-op.
+        diff = np.nansum(
+            np.abs(causal_with[0, local_mask] - causal_without[0, local_mask])
+        )
+        assert diff > 1e-6, (
+            "Override produced identical t=0 posterior to uniform IC; the "
+            "override is not actually changing the forward pass."
+        )

--- a/src/non_local_detector/tests/models/test_local_observation_channel.py
+++ b/src/non_local_detector/tests/models/test_local_observation_channel.py
@@ -377,12 +377,17 @@ class TestClusterlessOverride:
         local_mask = detector.state_ind_ == 0
         local_t0 = causal[0, local_mask]
         local_t0 = np.where(np.isnan(local_t0), 0.0, local_t0)
-        if local_t0.sum() > 0:
-            assert int(np.argmax(local_t0)) == animal_bin, (
-                f"Clusterless causal t=0 peaks at bin {int(np.argmax(local_t0))}, "
-                f"expected animal_bin={animal_bin}. Override may not be wired "
-                "through the clusterless predict() path."
-            )
+        # Guard against the test silently passing if the Local block were
+        # entirely zero/NaN (itself a regression mode).
+        assert local_t0.sum() > 0, (
+            "Clusterless Local mass at t=0 is zero or all-NaN; the override "
+            "or the forward pass produced no Local probability."
+        )
+        assert int(np.argmax(local_t0)) == animal_bin, (
+            f"Clusterless causal t=0 peaks at bin {int(np.argmax(local_t0))}, "
+            f"expected animal_bin={animal_bin}. Override may not be wired "
+            "through the clusterless predict() path."
+        )
 
 
 @pytest.mark.unit
@@ -438,15 +443,17 @@ class TestPredictUsesOverride:
         # The override puts all Local mass on `animal_bin` at t=0; the only
         # source of redistribution before the t=0 causal posterior is the
         # observation likelihood, which for σ=0.5 (much smaller than the
-        # bin spacing) leaves most mass near the animal. Compare against a
-        # uniform-IC baseline computed from the same posterior shape.
+        # bin spacing) leaves most mass near the animal.
         assert local_t0.shape == (n_local_bins,)
-        if local_t0.sum() > 0:
-            normalized = local_t0 / local_t0.sum()
-            assert int(np.argmax(normalized)) == animal_bin, (
-                f"Causal posterior at t=0 peaks at bin {int(np.argmax(normalized))}, "
-                f"expected animal_bin={animal_bin}. The IC override may not be wired."
-            )
+        # Guard: an all-zero/NaN Local block is itself a regression mode.
+        assert local_t0.sum() > 0, (
+            "Local mass at t=0 is zero or all-NaN; cannot test argmax."
+        )
+        normalized = local_t0 / local_t0.sum()
+        assert int(np.argmax(normalized)) == animal_bin, (
+            f"Causal posterior at t=0 peaks at bin {int(np.argmax(normalized))}, "
+            f"expected animal_bin={animal_bin}. The IC override may not be wired."
+        )
 
     def test_override_changes_t0_posterior_vs_uniform_ic(
         self, _fitted_detector, _sim_data

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -266,11 +266,9 @@ class TestComputeLocalPositionKernel:
         detector.initialize_state_index()
         return detector, position
 
-    def test_kernel_is_proper_log_density(self):
-        """Kernel matches scipy.stats.norm.logpdf on the distance the helper
-        actually uses (snap-aware ``Environment.get_distances_to_interior_bins``)."""
+    def test_kernel_is_anchor_shape_only_1d(self):
+        """1D-track kernel matches the anchor formula -0.5 * d² / σ² with peak 0."""
         import jax.numpy as jnp
-        from scipy.stats import norm
 
         from non_local_detector.likelihoods.common import get_position_at_time
 
@@ -282,16 +280,15 @@ class TestComputeLocalPositionKernel:
         position_time = np.array([0.0, 1.0])
         animal_position = np.array([[50.0], [50.0]])
 
-        log_kernel = detector._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
-        )
-        log_kernel_np = np.asarray(log_kernel)[0]
+        log_kernel = np.asarray(
+            detector._compute_local_position_kernel(
+                jnp.array(time),
+                jnp.array(position_time),
+                jnp.array(animal_position),
+                env,
+            )
+        )[0]
 
-        # Use the same distances the kernel uses internally so the test
-        # asserts the log-density formula, not the distance function.
         animal_pos_at_t = get_position_at_time(
             jnp.array(position_time),
             jnp.array(animal_position),
@@ -299,19 +296,20 @@ class TestComputeLocalPositionKernel:
             env,
         )
         distances = env.get_distances_to_interior_bins(np.asarray(animal_pos_at_t))[0]
-        expected = norm.logpdf(distances, loc=0.0, scale=sigma)
+        expected = -0.5 * distances**2 / sigma**2
 
-        np.testing.assert_allclose(log_kernel_np, expected, atol=1e-5, rtol=1e-5)
+        np.testing.assert_allclose(log_kernel, expected, atol=1e-5, rtol=1e-5)
+        # Anchor: peak is exactly 0 at the animal's bin (no normalizer).
+        assert float(log_kernel.max()) == pytest.approx(0.0, abs=1e-6)
 
-    def test_kernel_normalizer_2d_track_graphdd_environment(self):
-        """2D open-field uses the 2D isotropic Gaussian normalizer.
+    def test_kernel_is_anchor_shape_only_2d(self):
+        """2D open-field uses the same anchor formula — no n_dims normalizer.
 
         ``Environment.fit_place_grid`` builds ``track_graphDD`` for any
-        non-track-graph fit (including 2D open-field), and
-        ``get_distances_to_interior_bins`` then returns geodesic
-        distances on that grid graph — *not* Euclidean. Confirm the
-        kernel uses the position grid's coordinate dimension as
-        ``n_dims`` for that path.
+        non-track-graph fit (including 2D open-field), so distances are
+        geodesic on the grid. The anchor formula is shape-only, so 1D
+        and 2D environments use the same expression — σ controls
+        spatial tolerance, not a per-dimensional density normalization.
         """
         import jax.numpy as jnp
 
@@ -323,9 +321,8 @@ class TestComputeLocalPositionKernel:
         rng = np.random.default_rng(0)
         position_2d = rng.uniform(0.0, 20.0, size=(200, 2))
         env = env.fit_place_grid(position_2d, infer_track_interior=True)
-        assert env.track_graph is None  # no explicit linearized track
-        assert env.track_graphDD is not None  # built by fit_place_grid
-        assert env.distance_between_nodes_ is not None
+        assert env.track_graph is None
+        assert env.track_graphDD is not None
         assert env.place_bin_centers_.shape[1] == 2
 
         detector = NonLocalSortedSpikesDetector(local_position_std=sigma)
@@ -352,12 +349,9 @@ class TestComputeLocalPositionKernel:
             env,
         )
         distances = env.get_distances_to_interior_bins(np.asarray(animal_pos_at_t))[0]
-        n_dims = 2
-        expected = (
-            -0.5 * n_dims * np.log(2.0 * np.pi * sigma**2)
-            - 0.5 * distances**2 / sigma**2
-        )
+        expected = -0.5 * distances**2 / sigma**2
         np.testing.assert_allclose(log_kernel, expected, atol=1e-5, rtol=1e-5)
+        assert float(log_kernel.max()) == pytest.approx(0.0, abs=1e-6)
 
     def test_kernel_no_longer_sums_to_n_bins(self):
         """The proper Gaussian density does not satisfy exp.sum == n_bins."""
@@ -411,35 +405,50 @@ class TestComputeLocalPositionKernel:
         assert abs(peak_idx - nearest_bin_idx) <= 1
 
     def test_kernel_narrows_with_smaller_std(self):
-        """Kernel concentrates more with smaller local_position_std."""
+        """Smaller σ penalizes distant bins more heavily.
+
+        Both anchor-kernels peak at 0 at the animal's bin (no normalizer),
+        so the peak alone is insensitive to σ. Compare the kernel value at
+        a distant bin: narrow σ → much more negative log_kernel there.
+        """
         import jax.numpy as jnp
 
         time = np.array([0.5])
         position_time = np.array([0.0, 1.0])
         animal_position = np.array([[50.0], [50.0]])
 
-        # Wide kernel
         det_wide, _ = self._make_fitted_detector(local_position_std=20.0)
         env = det_wide.environments[0]
-        log_kernel_wide = det_wide._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
-        )
+        log_kernel_wide = np.asarray(
+            det_wide._compute_local_position_kernel(
+                jnp.array(time),
+                jnp.array(position_time),
+                jnp.array(animal_position),
+                env,
+            )
+        )[0]
 
-        # Narrow kernel
         det_narrow, _ = self._make_fitted_detector(local_position_std=2.0)
         env_n = det_narrow.environments[0]
-        log_kernel_narrow = det_narrow._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env_n,
-        )
+        log_kernel_narrow = np.asarray(
+            det_narrow._compute_local_position_kernel(
+                jnp.array(time),
+                jnp.array(position_time),
+                jnp.array(animal_position),
+                env_n,
+            )
+        )[0]
 
-        # Narrow kernel should have higher peak (more concentrated)
-        assert float(jnp.max(log_kernel_narrow)) > float(jnp.max(log_kernel_wide))
+        # Both peaks are 0 at the animal's bin.
+        np.testing.assert_allclose(log_kernel_wide.max(), 0.0, atol=1e-6)
+        np.testing.assert_allclose(log_kernel_narrow.max(), 0.0, atol=1e-6)
+        # Narrow σ is more negative at the bin farthest from the animal.
+        far_idx = int(
+            np.argmax(
+                np.abs(np.arange(log_kernel_wide.size) - log_kernel_wide.argmax())
+            )
+        )
+        assert log_kernel_narrow[far_idx] < log_kernel_wide[far_idx]
 
     def test_kernel_output_shape(self):
         """Output shape is (n_time, n_interior_bins)."""

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -303,6 +303,54 @@ class TestComputeLocalPositionKernel:
 
         np.testing.assert_allclose(log_kernel_np, expected, atol=1e-5, rtol=1e-5)
 
+    def test_kernel_normalizer_2d_euclidean_environment(self):
+        """Open-field 2D Euclidean fallback uses the 2D isotropic Gaussian normalizer."""
+        import jax.numpy as jnp
+
+        from non_local_detector.environment import Environment
+        from non_local_detector.likelihoods.common import get_position_at_time
+
+        sigma = 5.0
+        # Open-field 2D environment, no track graph.
+        env = Environment(environment_name="", place_bin_size=2.0)
+        rng = np.random.default_rng(0)
+        position_2d = rng.uniform(0.0, 20.0, size=(200, 2))
+        env = env.fit_place_grid(position_2d, infer_track_interior=True)
+        assert env.track_graph is None
+        assert env.place_bin_centers_.shape[1] == 2
+
+        detector = NonLocalSortedSpikesDetector(local_position_std=sigma)
+        detector.environments = (env,)
+        detector.initialize_state_index()
+
+        time = np.array([0.5])
+        position_time = np.array([0.0, 1.0])
+        animal_position = np.array([[10.0, 10.0], [10.0, 10.0]])
+
+        log_kernel = np.asarray(
+            detector._compute_local_position_kernel(
+                jnp.array(time),
+                jnp.array(position_time),
+                jnp.array(animal_position),
+                env,
+            )
+        )[0]
+
+        # Use the same distance the helper uses, with the 2D normalizer.
+        animal_pos_at_t = get_position_at_time(
+            jnp.array(position_time),
+            jnp.array(animal_position),
+            jnp.array(time),
+            env,
+        )
+        distances = env.get_distances_to_interior_bins(np.asarray(animal_pos_at_t))[0]
+        n_dims = 2
+        expected = (
+            -0.5 * n_dims * np.log(2.0 * np.pi * sigma**2)
+            - 0.5 * distances**2 / sigma**2
+        )
+        np.testing.assert_allclose(log_kernel, expected, atol=1e-5, rtol=1e-5)
+
     def test_kernel_no_longer_sums_to_n_bins(self):
         """The proper Gaussian density does not satisfy exp.sum == n_bins."""
         import jax.numpy as jnp

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -41,16 +41,12 @@ class TestLocalPositionStdValidation:
 
     def test_zero_rejected(self):
         """local_position_std=0 is rejected: Dirac density has no log form."""
-        with pytest.raises(
-            ValidationError, match="local_position_std must be a finite"
-        ):
+        with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalSortedSpikesDetector(local_position_std=0.0)
 
     def test_negative_rejected(self):
         """Negative local_position_std is rejected with ValidationError."""
-        with pytest.raises(
-            ValidationError, match="local_position_std must be a finite"
-        ):
+        with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalSortedSpikesDetector(local_position_std=-1.0)
 
     def test_clusterless_default_is_none(self):
@@ -65,16 +61,12 @@ class TestLocalPositionStdValidation:
 
     def test_clusterless_zero_rejected(self):
         """local_position_std=0 rejected on clusterless detector."""
-        with pytest.raises(
-            ValidationError, match="local_position_std must be a finite"
-        ):
+        with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalClusterlessDetector(local_position_std=0.0)
 
     def test_clusterless_negative_rejected(self):
         """Negative local_position_std rejected on clusterless detector."""
-        with pytest.raises(
-            ValidationError, match="local_position_std must be a finite"
-        ):
+        with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalClusterlessDetector(local_position_std=-1.0)
 
 

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -49,6 +49,16 @@ class TestLocalPositionStdValidation:
         with pytest.raises(ValidationError, match="local_position_std"):
             NonLocalSortedSpikesDetector(local_position_std=-1.0)
 
+    def test_float32_underflow_rejected(self):
+        """Positive σ that underflows to 0 in float32 is rejected.
+
+        The kernel evaluates ``-0.5 * d^2 / sigma^2`` at float32 precision,
+        so a positive but unrepresentably-small σ would silently divide by
+        zero. Callers should pass 0.0 explicitly for the delta kernel.
+        """
+        with pytest.raises(ValidationError, match="underflow"):
+            NonLocalSortedSpikesDetector(local_position_std=1e-50)
+
     def test_clusterless_default_is_none(self):
         """Default local_position_std is None on clusterless detector."""
         detector = NonLocalClusterlessDetector()

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -1,8 +1,8 @@
 """Tests for local_position_std parameter on detector classes.
 
 Tests cover:
-- Parameter acceptance (None default, positive values)
-- Validation rejection (zero, negative values)
+- Parameter acceptance (None default, 0.0 delta-kernel mode, positive values)
+- Validation rejection (negative values, NaN/Inf, float32-square underflow)
 - Parameter storage on instance
 - Backward compatibility (None preserves legacy behavior)
 - State index allocation (multi-bin vs single-bin local)
@@ -50,14 +50,20 @@ class TestLocalPositionStdValidation:
             NonLocalSortedSpikesDetector(local_position_std=-1.0)
 
     def test_float32_underflow_rejected(self):
-        """Positive σ that underflows to 0 in float32 is rejected.
+        """Positive σ whose float32 square underflows to 0 is rejected.
 
-        The kernel evaluates ``-0.5 * d^2 / sigma^2`` at float32 precision,
-        so a positive but unrepresentably-small σ would silently divide by
-        zero. Callers should pass 0.0 explicitly for the delta kernel.
+        The kernel evaluates ``-0.5 * d^2 / sigma^2`` at float32 precision.
+        A σ like ``1e-19`` is representable in float32, but ``σ**2`` is not
+        — it underflows to 0 and the kernel becomes a divide-by-zero. The
+        validator must reject based on the *squared* denominator, not σ
+        itself. Callers who want delta semantics should pass 0.0.
         """
+        # σ that underflows directly (σ ≈ 0 in float32).
         with pytest.raises(ValidationError, match="underflow"):
             NonLocalSortedSpikesDetector(local_position_std=1e-50)
+        # σ representable in float32 but whose square underflows to 0.
+        with pytest.raises(ValidationError, match="underflow"):
+            NonLocalSortedSpikesDetector(local_position_std=1e-19)
 
     def test_clusterless_default_is_none(self):
         """Default local_position_std is None on clusterless detector."""

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -303,20 +303,29 @@ class TestComputeLocalPositionKernel:
 
         np.testing.assert_allclose(log_kernel_np, expected, atol=1e-5, rtol=1e-5)
 
-    def test_kernel_normalizer_2d_euclidean_environment(self):
-        """Open-field 2D Euclidean fallback uses the 2D isotropic Gaussian normalizer."""
+    def test_kernel_normalizer_2d_track_graphdd_environment(self):
+        """2D open-field uses the 2D isotropic Gaussian normalizer.
+
+        ``Environment.fit_place_grid`` builds ``track_graphDD`` for any
+        non-track-graph fit (including 2D open-field), and
+        ``get_distances_to_interior_bins`` then returns geodesic
+        distances on that grid graph — *not* Euclidean. Confirm the
+        kernel uses the position grid's coordinate dimension as
+        ``n_dims`` for that path.
+        """
         import jax.numpy as jnp
 
         from non_local_detector.environment import Environment
         from non_local_detector.likelihoods.common import get_position_at_time
 
         sigma = 5.0
-        # Open-field 2D environment, no track graph.
         env = Environment(environment_name="", place_bin_size=2.0)
         rng = np.random.default_rng(0)
         position_2d = rng.uniform(0.0, 20.0, size=(200, 2))
         env = env.fit_place_grid(position_2d, infer_track_interior=True)
-        assert env.track_graph is None
+        assert env.track_graph is None  # no explicit linearized track
+        assert env.track_graphDD is not None  # built by fit_place_grid
+        assert env.distance_between_nodes_ is not None
         assert env.place_bin_centers_.shape[1] == 2
 
         detector = NonLocalSortedSpikesDetector(local_position_std=sigma)
@@ -336,7 +345,6 @@ class TestComputeLocalPositionKernel:
             )
         )[0]
 
-        # Use the same distance the helper uses, with the 2D normalizer.
         animal_pos_at_t = get_position_at_time(
             jnp.array(position_time),
             jnp.array(animal_position),

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -39,10 +39,10 @@ class TestLocalPositionStdValidation:
         detector = NonLocalSortedSpikesDetector(local_position_std=0.01)
         assert detector.local_position_std == 0.01
 
-    def test_zero_rejected(self):
-        """local_position_std=0 is rejected: Dirac density has no log form."""
-        with pytest.raises(ValidationError, match="local_position_std"):
-            NonLocalSortedSpikesDetector(local_position_std=0.0)
+    def test_zero_accepted(self):
+        """local_position_std=0 is accepted (delta-kernel mode)."""
+        detector = NonLocalSortedSpikesDetector(local_position_std=0.0)
+        assert detector.local_position_std == 0.0
 
     def test_negative_rejected(self):
         """Negative local_position_std is rejected with ValidationError."""
@@ -59,10 +59,10 @@ class TestLocalPositionStdValidation:
         detector = NonLocalClusterlessDetector(local_position_std=5.0)
         assert detector.local_position_std == 5.0
 
-    def test_clusterless_zero_rejected(self):
-        """local_position_std=0 rejected on clusterless detector."""
-        with pytest.raises(ValidationError, match="local_position_std"):
-            NonLocalClusterlessDetector(local_position_std=0.0)
+    def test_clusterless_zero_accepted(self):
+        """local_position_std=0 accepted on clusterless detector (delta mode)."""
+        detector = NonLocalClusterlessDetector(local_position_std=0.0)
+        assert detector.local_position_std == 0.0
 
     def test_clusterless_negative_rejected(self):
         """Negative local_position_std rejected on clusterless detector."""

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -42,14 +42,14 @@ class TestLocalPositionStdValidation:
     def test_zero_rejected(self):
         """local_position_std=0 is rejected: Dirac density has no log form."""
         with pytest.raises(
-            ValidationError, match="local_position_std must be strictly positive"
+            ValidationError, match="local_position_std must be a finite"
         ):
             NonLocalSortedSpikesDetector(local_position_std=0.0)
 
     def test_negative_rejected(self):
         """Negative local_position_std is rejected with ValidationError."""
         with pytest.raises(
-            ValidationError, match="local_position_std must be strictly positive"
+            ValidationError, match="local_position_std must be a finite"
         ):
             NonLocalSortedSpikesDetector(local_position_std=-1.0)
 
@@ -66,14 +66,14 @@ class TestLocalPositionStdValidation:
     def test_clusterless_zero_rejected(self):
         """local_position_std=0 rejected on clusterless detector."""
         with pytest.raises(
-            ValidationError, match="local_position_std must be strictly positive"
+            ValidationError, match="local_position_std must be a finite"
         ):
             NonLocalClusterlessDetector(local_position_std=0.0)
 
     def test_clusterless_negative_rejected(self):
         """Negative local_position_std rejected on clusterless detector."""
         with pytest.raises(
-            ValidationError, match="local_position_std must be strictly positive"
+            ValidationError, match="local_position_std must be a finite"
         ):
             NonLocalClusterlessDetector(local_position_std=-1.0)
 

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -354,7 +354,7 @@ class TestComputeLocalPositionKernel:
         assert float(log_kernel.max()) == pytest.approx(0.0, abs=1e-6)
 
     def test_kernel_no_longer_sums_to_n_bins(self):
-        """The proper Gaussian density does not satisfy exp.sum == n_bins."""
+        """The unnormalized anchor kernel does not satisfy exp.sum == n_bins."""
         import jax.numpy as jnp
 
         detector, position = self._make_fitted_detector(local_position_std=5.0)

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -282,9 +282,16 @@ class TestComputeLocalPositionKernel:
         detector.initialize_state_index()
         return detector, position
 
-    def test_kernel_is_anchor_shape_only_1d(self):
-        """1D-track kernel matches the anchor formula -0.5 * d² / σ² with peak 0."""
+    def test_kernel_is_anchor_shape_with_n_bins_compensation_1d(self):
+        """1D kernel: shape -0.5 d²/σ², rescaled so exp(log_kernel) sums to n_bins.
+
+        The rescaling compensates for the multi-bin Local state's
+        ``1/n_bins`` uniform continuous IC; without it Non-Local
+        dominates by a factor of n_bins (verified by simulated-data
+        smoke check).
+        """
         import jax.numpy as jnp
+        from scipy.special import logsumexp
 
         from non_local_detector.likelihoods.common import get_position_at_time
 
@@ -312,22 +319,27 @@ class TestComputeLocalPositionKernel:
             env,
         )
         distances = env.get_distances_to_interior_bins(np.asarray(animal_pos_at_t))[0]
-        expected = -0.5 * distances**2 / sigma**2
-
+        n_bins = int(env.is_track_interior_.sum())
+        raw = -0.5 * distances**2 / sigma**2
+        expected = raw - logsumexp(raw) + np.log(n_bins)
         np.testing.assert_allclose(log_kernel, expected, atol=1e-5, rtol=1e-5)
-        # Anchor: peak is exactly 0 at the animal's bin (no normalizer).
-        assert float(log_kernel.max()) == pytest.approx(0.0, abs=1e-6)
+        # Mass balance: exp(log_kernel) sums to n_bins per timestep.
+        np.testing.assert_allclose(
+            float(np.exp(log_kernel).sum()), float(n_bins), rtol=1e-5
+        )
 
-    def test_kernel_is_anchor_shape_only_2d(self):
-        """2D open-field uses the same anchor formula — no n_dims normalizer.
+    def test_kernel_is_anchor_shape_with_n_bins_compensation_2d(self):
+        """2D open-field uses the same anchor formula with the same scaling.
 
         ``Environment.fit_place_grid`` builds ``track_graphDD`` for any
         non-track-graph fit (including 2D open-field), so distances are
-        geodesic on the grid. The anchor formula is shape-only, so 1D
-        and 2D environments use the same expression — σ controls
-        spatial tolerance, not a per-dimensional density normalization.
+        geodesic on the grid. The kernel formula is shape-only — σ
+        controls spatial tolerance, not a per-dimensional density
+        normalization — and the same n_bins mass-balance scaling
+        applies in 1D and 2D.
         """
         import jax.numpy as jnp
+        from scipy.special import logsumexp
 
         from non_local_detector.environment import Environment
         from non_local_detector.likelihoods.common import get_position_at_time
@@ -365,32 +377,45 @@ class TestComputeLocalPositionKernel:
             env,
         )
         distances = env.get_distances_to_interior_bins(np.asarray(animal_pos_at_t))[0]
-        expected = -0.5 * distances**2 / sigma**2
+        n_bins = int(env.is_track_interior_.sum())
+        raw = -0.5 * distances**2 / sigma**2
+        # Reachable-only logsumexp (unreachable bins are -inf and drop).
+        finite = np.isfinite(raw)
+        expected = np.where(
+            finite, raw - logsumexp(raw[finite]) + np.log(n_bins), -np.inf
+        )
         np.testing.assert_allclose(log_kernel, expected, atol=1e-5, rtol=1e-5)
-        assert float(log_kernel.max()) == pytest.approx(0.0, abs=1e-6)
+        np.testing.assert_allclose(
+            float(np.exp(log_kernel[finite]).sum()), float(n_bins), rtol=1e-5
+        )
 
-    def test_kernel_no_longer_sums_to_n_bins(self):
-        """The unnormalized anchor kernel does not satisfy exp.sum == n_bins."""
+    def test_kernel_sums_to_n_bins_per_timestep(self):
+        """exp(log_kernel) sums to n_bins per timestep (mass-balance contract).
+
+        Required for fair Local-vs-Non-Local mass balance under the
+        multi-bin Local state's uniform 1/n_bins continuous IC.
+        """
         import jax.numpy as jnp
 
         detector, position = self._make_fitted_detector(local_position_std=5.0)
         env = detector.environments[0]
 
-        time = np.array([0.5])
+        time = np.array([0.0, 0.5, 1.0])
         position_time = np.array([0.0, 1.0])
-        animal_position = np.array([[50.0], [50.0]])
+        animal_position = np.array([[20.0], [70.0]])
 
-        log_kernel = detector._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
+        log_kernel = np.asarray(
+            detector._compute_local_position_kernel(
+                jnp.array(time),
+                jnp.array(position_time),
+                jnp.array(animal_position),
+                env,
+            )
         )
         n_interior = int(env.is_track_interior_.sum())
-        # The compensation has been removed; the row sum is governed by
-        # bin spacing and σ and is, in general, not n_bins.
-        row_sum = float(np.exp(np.asarray(log_kernel)).sum())
-        assert not np.isclose(row_sum, n_interior, rtol=1e-3)
+        finite = np.isfinite(log_kernel)
+        row_sums = (np.exp(log_kernel) * finite).sum(axis=1)
+        np.testing.assert_allclose(row_sums, n_interior, rtol=1e-5)
 
     def test_kernel_peak_at_nearest_bin(self):
         """Kernel peak is at the bin nearest to animal position."""
@@ -423,9 +448,10 @@ class TestComputeLocalPositionKernel:
     def test_kernel_narrows_with_smaller_std(self):
         """Smaller σ penalizes distant bins more heavily.
 
-        Both anchor-kernels peak at 0 at the animal's bin (no normalizer),
-        so the peak alone is insensitive to σ. Compare the kernel value at
-        a distant bin: narrow σ → much more negative log_kernel there.
+        Both kernels are normalized to sum to n_bins, so the *shape*
+        (relative weight at a distant bin vs the peak) is what changes
+        with σ. Narrow σ → more peaked → distant log_kernel is more
+        negative relative to the peak.
         """
         import jax.numpy as jnp
 
@@ -455,16 +481,18 @@ class TestComputeLocalPositionKernel:
             )
         )[0]
 
-        # Both peaks are 0 at the animal's bin.
-        np.testing.assert_allclose(log_kernel_wide.max(), 0.0, atol=1e-6)
-        np.testing.assert_allclose(log_kernel_narrow.max(), 0.0, atol=1e-6)
-        # Narrow σ is more negative at the bin farthest from the animal.
+        # Compare relative peak-to-far drop, since the absolute peak
+        # depends on the rescaling.
+        peak_wide = log_kernel_wide.max()
+        peak_narrow = log_kernel_narrow.max()
         far_idx = int(
             np.argmax(
                 np.abs(np.arange(log_kernel_wide.size) - log_kernel_wide.argmax())
             )
         )
-        assert log_kernel_narrow[far_idx] < log_kernel_wide[far_idx]
+        drop_wide = peak_wide - log_kernel_wide[far_idx]
+        drop_narrow = peak_narrow - log_kernel_narrow[far_idx]
+        assert drop_narrow > drop_wide
 
     def test_kernel_output_shape(self):
         """Output shape is (n_time, n_interior_bins)."""

--- a/src/non_local_detector/tests/models/test_local_position_std.py
+++ b/src/non_local_detector/tests/models/test_local_position_std.py
@@ -39,15 +39,17 @@ class TestLocalPositionStdValidation:
         detector = NonLocalSortedSpikesDetector(local_position_std=0.01)
         assert detector.local_position_std == 0.01
 
-    def test_zero_accepted(self):
-        """local_position_std=0 is accepted (delta-kernel mode)."""
-        detector = NonLocalSortedSpikesDetector(local_position_std=0.0)
-        assert detector.local_position_std == 0.0
+    def test_zero_rejected(self):
+        """local_position_std=0 is rejected: Dirac density has no log form."""
+        with pytest.raises(
+            ValidationError, match="local_position_std must be strictly positive"
+        ):
+            NonLocalSortedSpikesDetector(local_position_std=0.0)
 
     def test_negative_rejected(self):
         """Negative local_position_std is rejected with ValidationError."""
         with pytest.raises(
-            ValidationError, match="local_position_std must be non-negative"
+            ValidationError, match="local_position_std must be strictly positive"
         ):
             NonLocalSortedSpikesDetector(local_position_std=-1.0)
 
@@ -61,15 +63,17 @@ class TestLocalPositionStdValidation:
         detector = NonLocalClusterlessDetector(local_position_std=5.0)
         assert detector.local_position_std == 5.0
 
-    def test_clusterless_zero_accepted(self):
-        """local_position_std=0 accepted on clusterless detector (delta mode)."""
-        detector = NonLocalClusterlessDetector(local_position_std=0.0)
-        assert detector.local_position_std == 0.0
+    def test_clusterless_zero_rejected(self):
+        """local_position_std=0 rejected on clusterless detector."""
+        with pytest.raises(
+            ValidationError, match="local_position_std must be strictly positive"
+        ):
+            NonLocalClusterlessDetector(local_position_std=0.0)
 
     def test_clusterless_negative_rejected(self):
         """Negative local_position_std rejected on clusterless detector."""
         with pytest.raises(
-            ValidationError, match="local_position_std must be non-negative"
+            ValidationError, match="local_position_std must be strictly positive"
         ):
             NonLocalClusterlessDetector(local_position_std=-1.0)
 
@@ -270,17 +274,21 @@ class TestComputeLocalPositionKernel:
         detector.initialize_state_index()
         return detector, position
 
-    def test_kernel_is_valid_log_probability(self):
-        """Kernel exp sums to 1 per time step (valid log-probability)."""
+    def test_kernel_is_proper_log_density(self):
+        """Kernel matches scipy.stats.norm.logpdf on the distance the helper
+        actually uses (snap-aware ``Environment.get_distances_to_interior_bins``)."""
         import jax.numpy as jnp
+        from scipy.stats import norm
 
-        detector, position = self._make_fitted_detector(local_position_std=5.0)
+        from non_local_detector.likelihoods.common import get_position_at_time
+
+        sigma = 5.0
+        detector, position = self._make_fitted_detector(local_position_std=sigma)
         env = detector.environments[0]
 
-        n_time = 10
-        time = np.linspace(0, 1, n_time)
-        position_time = np.linspace(0, 1, 50)
-        animal_position = np.linspace(10, 90, 50)[:, np.newaxis]
+        time = np.array([0.5])
+        position_time = np.array([0.0, 1.0])
+        animal_position = np.array([[50.0], [50.0]])
 
         log_kernel = detector._compute_local_position_kernel(
             jnp.array(time),
@@ -288,14 +296,43 @@ class TestComputeLocalPositionKernel:
             jnp.array(animal_position),
             env,
         )
+        log_kernel_np = np.asarray(log_kernel)[0]
 
-        # exp(log_kernel) should sum to n_interior_bins per time step
-        # (scaled to compensate for 1/n_bins uniform continuous IC).
-        # JAX computes in float32, so use rtol=1e-5.
-        probs = np.exp(np.asarray(log_kernel))
-        row_sums = probs.sum(axis=1)
+        # Use the same distances the kernel uses internally so the test
+        # asserts the log-density formula, not the distance function.
+        animal_pos_at_t = get_position_at_time(
+            jnp.array(position_time),
+            jnp.array(animal_position),
+            jnp.array(time),
+            env,
+        )
+        distances = env.get_distances_to_interior_bins(np.asarray(animal_pos_at_t))[0]
+        expected = norm.logpdf(distances, loc=0.0, scale=sigma)
+
+        np.testing.assert_allclose(log_kernel_np, expected, atol=1e-5, rtol=1e-5)
+
+    def test_kernel_no_longer_sums_to_n_bins(self):
+        """The proper Gaussian density does not satisfy exp.sum == n_bins."""
+        import jax.numpy as jnp
+
+        detector, position = self._make_fitted_detector(local_position_std=5.0)
+        env = detector.environments[0]
+
+        time = np.array([0.5])
+        position_time = np.array([0.0, 1.0])
+        animal_position = np.array([[50.0], [50.0]])
+
+        log_kernel = detector._compute_local_position_kernel(
+            jnp.array(time),
+            jnp.array(position_time),
+            jnp.array(animal_position),
+            env,
+        )
         n_interior = int(env.is_track_interior_.sum())
-        np.testing.assert_allclose(row_sums, n_interior, rtol=1e-5)
+        # The compensation has been removed; the row sum is governed by
+        # bin spacing and σ and is, in general, not n_bins.
+        row_sum = float(np.exp(np.asarray(log_kernel)).sum())
+        assert not np.isclose(row_sum, n_interior, rtol=1e-3)
 
     def test_kernel_peak_at_nearest_bin(self):
         """Kernel peak is at the bin nearest to animal position."""
@@ -400,13 +437,8 @@ class TestComputeLocalPositionKernel:
         # Should not contain NaN
         log_kernel_np = np.asarray(log_kernel)
         assert np.all(np.isfinite(log_kernel_np))
-        # Should be uniform (all equal values, all zero since exp=1 per bin)
-        np.testing.assert_allclose(log_kernel_np[0], log_kernel_np[0, 0], atol=1e-6)
-        # exp should sum to n_interior_bins (scaled normalization)
-        n_interior = int(env.is_track_interior_.sum())
-        np.testing.assert_allclose(
-            np.exp(log_kernel_np[0]).sum(), n_interior, rtol=1e-5
-        )
+        # Uniform fallback returns log_kernel = 0 everywhere (flat).
+        np.testing.assert_allclose(log_kernel_np[0], 0.0, atol=1e-6)
 
     def test_kernel_with_track_graph(self):
         """Kernel uses track graph distances when track graph is available."""
@@ -450,13 +482,8 @@ class TestComputeLocalPositionKernel:
         log_kernel_np = np.asarray(log_kernel)
         # Should be finite (no NaN from track graph path)
         assert np.all(np.isfinite(log_kernel_np))
-        # Should sum to n_interior_bins in probability space
-        is_interior = env.is_track_interior_.ravel()
-        n_interior = int(is_interior.sum())
-        np.testing.assert_allclose(
-            np.exp(log_kernel_np[0]).sum(), n_interior, rtol=1e-5
-        )
         # Peak should be near position 50
+        is_interior = env.is_track_interior_.ravel()
         bin_centers = env.place_bin_centers_[is_interior].ravel()
         peak_idx = int(np.argmax(log_kernel_np[0]))
         assert abs(bin_centers[peak_idx] - 50.0) < 10.0
@@ -541,300 +568,4 @@ class TestComputeLocalPositionKernel:
         assert np.all(np.isneginf(arm_b_log_kernel)), (
             "Arm-B bins should be unreachable from arm A; expected -inf "
             f"log-probability, got: {arm_b_log_kernel}"
-        )
-
-
-@pytest.mark.unit
-class TestDeltaKernel:
-    """Delta kernel (local_position_std=0) tests.
-
-    With σ=0 the Local state's kernel collapses to a one-hot at the
-    animal's bin: log(n_bins) at that bin, -inf elsewhere. After the
-    multi-bin state's 1/n_bins uniform continuous IC, the total Local
-    mass equals ``p_local × P(spikes | animal_bin_center)``.
-    """
-
-    def _make_detector_and_env(self):
-        detector = NonLocalSortedSpikesDetector(local_position_std=0.0)
-        position = np.linspace(0, 100, 50)[:, np.newaxis]
-        detector.initialize_environments(position)
-        detector.initialize_state_index()
-        return detector, detector.environments[0]
-
-    def test_kernel_is_one_hot_at_animal_bin(self):
-        """At σ=0 the kernel is log(n_bins) at one bin and -inf elsewhere."""
-        import jax.numpy as jnp
-
-        detector, env = self._make_detector_and_env()
-
-        time = np.array([0.5])
-        position_time = np.array([0.0, 1.0])
-        animal_position = np.array([[50.0], [50.0]])
-
-        log_kernel = detector._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
-        )
-        log_kernel_np = np.asarray(log_kernel)
-
-        n_interior = int(env.is_track_interior_.sum())
-        # One entry equals log(n_bins); all others are -inf.
-        finite_mask = np.isfinite(log_kernel_np[0])
-        assert finite_mask.sum() == 1, "Delta kernel must be non-inf at exactly one bin"
-        np.testing.assert_allclose(
-            log_kernel_np[0][finite_mask],
-            np.log(n_interior),
-            rtol=1e-6,
-        )
-        # -inf elsewhere
-        assert np.all(log_kernel_np[0][~finite_mask] == -np.inf)
-
-    def test_kernel_peak_at_animal_bin(self):
-        """The single finite bin is the one containing the animal."""
-        import jax.numpy as jnp
-
-        detector, env = self._make_detector_and_env()
-        time = np.array([0.5])
-        position_time = np.array([0.0, 1.0])
-        animal_position = np.array([[50.0], [50.0]])
-
-        log_kernel = detector._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
-        )
-        log_kernel_np = np.asarray(log_kernel)
-
-        # Find which interior bin contains animal position 50
-        interior_bin_indices = np.where(env.is_track_interior_.ravel())[0]
-        expected_bin_ind = env.get_bin_ind(np.array([[50.0]]))[0]
-        # Convert full-bin index to interior-bin index (column index in log_kernel)
-        expected_col = int(np.where(interior_bin_indices == expected_bin_ind)[0][0])
-
-        peak_col = int(np.argmax(log_kernel_np[0]))
-        assert peak_col == expected_col
-
-    def test_kernel_sums_to_n_bins_in_prob_space(self):
-        """exp(log_kernel) sums to n_bins per time step — same invariant as σ>0."""
-        import jax.numpy as jnp
-
-        detector, env = self._make_detector_and_env()
-        time = np.linspace(0.0, 1.0, 5)
-        position_time = np.linspace(0.0, 1.0, 10)
-        animal_position = np.linspace(10, 90, 10)[:, np.newaxis]
-
-        log_kernel = detector._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
-        )
-        log_kernel_np = np.asarray(log_kernel)
-
-        n_interior = int(env.is_track_interior_.sum())
-        # exp(log(n_bins)) + exp(-inf)*(n-1) = n_bins exactly
-        np.testing.assert_allclose(
-            np.exp(log_kernel_np).sum(axis=1), n_interior, rtol=1e-6
-        )
-
-    def test_nan_position_produces_uniform_fallback(self):
-        """NaN animal position → uniform kernel (all 0 in log-space)."""
-        import jax.numpy as jnp
-
-        detector, env = self._make_detector_and_env()
-        time = np.array([0.5])
-        position_time = np.array([0.0, 1.0])
-        animal_position = np.array([[np.nan], [np.nan]])
-
-        log_kernel = detector._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
-        )
-        log_kernel_np = np.asarray(log_kernel)
-
-        assert np.all(np.isfinite(log_kernel_np)), (
-            "NaN fallback must produce finite kernel (uniform, 0 in log)"
-        )
-        np.testing.assert_allclose(log_kernel_np[0], 0.0, atol=1e-6)
-
-    def test_delta_kernel_gap_position_snaps_to_nearest_interior(self):
-        """Animal in a gap bin snaps to nearest interior bin via get_bin_ind.
-
-        Prior to the get_bin_ind snap fix, positions landing in gap bins
-        (e.g. exactly on an arm-boundary edge, or in the middle of a gap)
-        produced a uniform fallback. Now they snap to the nearest interior
-        bin by position distance, so the delta fires at that snapped bin.
-        """
-        import jax.numpy as jnp
-        import networkx as nx
-
-        from non_local_detector.environment import Environment
-
-        g = nx.Graph()
-        g.add_node(0, pos=(0.0, 0.0))
-        g.add_node(1, pos=(50.0, 0.0))
-        g.add_node(2, pos=(60.0, 0.0))
-        g.add_node(3, pos=(110.0, 0.0))
-        g.add_edge(0, 1, distance=50.0, edge_id=0)
-        g.add_edge(2, 3, distance=50.0, edge_id=1)
-
-        env = Environment(
-            environment_name="",
-            place_bin_size=5.0,
-            track_graph=g,
-            edge_order=[(0, 1), (2, 3)],
-            edge_spacing=10.0,
-        )
-        position_1d = np.concatenate(
-            [np.linspace(0.0, 50.0, 25), np.linspace(60.0, 110.0, 25)]
-        )
-        env = env.fit_place_grid(position_1d, infer_track_interior=True)
-
-        detector = NonLocalSortedSpikesDetector(local_position_std=0.0)
-        detector.environments = (env,)
-        detector.initialize_state_index()
-
-        is_interior = env.is_track_interior_.ravel()
-        gap_bins = np.where(~is_interior)[0]
-        gap_center = float(env.place_bin_centers_[gap_bins[0], 0])
-
-        time = np.array([0.5])
-        position_time = np.array([0.0, 1.0])
-        animal_position = np.array([[gap_center], [gap_center]])
-
-        log_kernel = detector._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
-        )
-        lk = np.asarray(log_kernel)
-
-        # Delta kernel: exactly one finite entry (the snapped interior bin),
-        # all others -inf. Not uniform.
-        assert np.isfinite(lk[0]).sum() == 1, (
-            f"Expected exactly one finite entry (delta), got "
-            f"{int(np.isfinite(lk[0]).sum())}. Row: {lk[0]}"
-        )
-        # The snapped bin should be the arm-A last interior bin (closer
-        # than arm-B first interior bin when the gap is wide and place_bin_size
-        # is small — here arm-A-last and arm-B-first are equidistant from the
-        # gap center, so we just assert the finite entry is one of them).
-        finite_idx = int(np.where(np.isfinite(lk[0]))[0][0])
-        interior_centers = env.place_bin_centers_[is_interior, 0]
-        # Distance from gap center to the snapped bin must be <= distance to
-        # any other interior bin.
-        dist_to_snapped = abs(interior_centers[finite_idx] - gap_center)
-        assert dist_to_snapped == np.min(np.abs(interior_centers - gap_center)), (
-            f"Snap didn't pick the nearest interior bin. "
-            f"Snapped: {interior_centers[finite_idx]}, gap center: {gap_center}"
-        )
-
-    def test_delta_kernel_at_arm_end_edge(self):
-        """The exact float-equality bug case: animal on arm-A end edge snaps to arm A."""
-        import jax.numpy as jnp
-        import networkx as nx
-
-        from non_local_detector.environment import Environment
-
-        g = nx.Graph()
-        g.add_node(0, pos=(0.0, 0.0))
-        g.add_node(1, pos=(50.0, 0.0))
-        g.add_node(2, pos=(60.0, 0.0))
-        g.add_node(3, pos=(110.0, 0.0))
-        g.add_edge(0, 1, distance=50.0, edge_id=0)
-        g.add_edge(2, 3, distance=50.0, edge_id=1)
-
-        env = Environment(
-            environment_name="",
-            place_bin_size=5.0,
-            track_graph=g,
-            edge_order=[(0, 1), (2, 3)],
-            edge_spacing=10.0,
-        )
-        position_1d = np.concatenate(
-            [np.linspace(0.0, 50.0, 25), np.linspace(60.0, 110.0, 25)]
-        )
-        env = env.fit_place_grid(position_1d, infer_track_interior=True)
-
-        detector = NonLocalSortedSpikesDetector(local_position_std=0.0)
-        detector.environments = (env,)
-        detector.initialize_state_index()
-
-        # Use the exact arm-A-end edge value (the real-data bug case).
-        is_interior = env.is_track_interior_.ravel()
-        first_gap = int(np.where(~is_interior)[0][0])
-        arm_end = float(env.edges_[0][first_gap])
-
-        time = np.array([0.5])
-        position_time = np.array([0.0, 1.0])
-        animal_position = np.array([[arm_end], [arm_end]])
-
-        log_kernel = detector._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
-        )
-        lk = np.asarray(log_kernel)
-
-        # Exactly one finite entry at the arm-A last interior bin.
-        assert np.isfinite(lk[0]).sum() == 1
-        interior_bin_indices = np.where(is_interior)[0]
-        expected_interior_idx = int(np.sum(interior_bin_indices < first_gap) - 1)
-        finite_idx = int(np.where(np.isfinite(lk[0]))[0][0])
-        assert finite_idx == expected_interior_idx, (
-            f"Expected snap to arm-A last interior bin (index "
-            f"{expected_interior_idx}), got {finite_idx}"
-        )
-
-    def test_kernel_with_track_graph(self):
-        """Delta kernel works on an Environment with a track_graph."""
-        import jax.numpy as jnp
-        import networkx as nx
-
-        from non_local_detector.environment import Environment
-
-        track_graph = nx.Graph()
-        track_graph.add_node(0, pos=(0.0, 0.0))
-        track_graph.add_node(1, pos=(100.0, 0.0))
-        track_graph.add_edge(0, 1, distance=100.0, edge_id=0)
-
-        env = Environment(
-            environment_name="",
-            place_bin_size=5.0,
-            track_graph=track_graph,
-            edge_order=[(0, 1)],
-            edge_spacing=0.0,
-        )
-        env = env.fit_place_grid(np.linspace(0, 100, 50), infer_track_interior=True)
-
-        detector = NonLocalSortedSpikesDetector(local_position_std=0.0)
-        detector.environments = (env,)
-        detector.initialize_state_index()
-
-        time = np.array([0.5])
-        position_time = np.array([0.0, 1.0])
-        animal_position = np.array([[50.0], [50.0]])
-
-        log_kernel = detector._compute_local_position_kernel(
-            jnp.array(time),
-            jnp.array(position_time),
-            jnp.array(animal_position),
-            env,
-        )
-        log_kernel_np = np.asarray(log_kernel)
-
-        n_interior = int(env.is_track_interior_.sum())
-        finite_mask = np.isfinite(log_kernel_np[0])
-        assert finite_mask.sum() == 1
-        np.testing.assert_allclose(
-            log_kernel_np[0][finite_mask],
-            np.log(n_interior),
-            rtol=1e-6,
         )

--- a/src/non_local_detector/tests/models/test_local_position_std_snapshot.py
+++ b/src/non_local_detector/tests/models/test_local_position_std_snapshot.py
@@ -137,7 +137,7 @@ class TestLocalPositionStdSnapshot:
         finite negative marginal log-likelihood. If mass-balance or
         normalization breaks, this can go positive or become -inf.
         """
-        for sigma in (None, 0.5, 5.0):
+        for sigma in (None, 0.0, 0.5, 5.0):
             detector = NonLocalSortedSpikesDetector(
                 sampling_frequency=_sim_data["sampling_frequency"],
                 local_position_std=sigma,

--- a/src/non_local_detector/tests/models/test_local_position_std_snapshot.py
+++ b/src/non_local_detector/tests/models/test_local_position_std_snapshot.py
@@ -130,64 +130,6 @@ class TestLocalPositionStdSnapshot:
             np.isneginf(acausal_safe)
         ), "Posterior must not contain Inf"
 
-    def test_sharp_sigma_approaches_delta_kernel(self, _sim_data):
-        """Narrow σ converges toward the delta-kernel path numerically.
-
-        If the normalization constant (log(n_bins) mass-balance) is ever
-        changed, the sharp-σ limit will diverge from the δ=0 path and
-        this test will catch it.
-        """
-        # Small σ: close to delta in behavior.
-        detector_sharp = NonLocalSortedSpikesDetector(
-            sampling_frequency=_sim_data["sampling_frequency"],
-            local_position_std=0.5,
-        )
-        # Exact delta.
-        detector_delta = NonLocalSortedSpikesDetector(
-            sampling_frequency=_sim_data["sampling_frequency"],
-            local_position_std=0.0,
-        )
-
-        for det in (detector_sharp, detector_delta):
-            det.fit(
-                position_time=_sim_data["time"],
-                position=_sim_data["position"],
-                spike_times=_sim_data["spike_times"],
-            )
-
-        r_sharp = detector_sharp.predict(
-            spike_times=_sim_data["spike_times"],
-            position_time=_sim_data["time"],
-            position=_sim_data["position"],
-            time=_sim_data["time"],
-        )
-        r_delta = detector_delta.predict(
-            spike_times=_sim_data["spike_times"],
-            position_time=_sim_data["time"],
-            position=_sim_data["position"],
-            time=_sim_data["time"],
-        )
-
-        sp_sharp = np.asarray(r_sharp.acausal_state_probabilities)
-        sp_delta = np.asarray(r_delta.acausal_state_probabilities)
-
-        # Mean per-state probabilities differ in detail but the ordering
-        # of states (which state dominates on average) is stable.
-        assert np.argmax(sp_sharp.mean(axis=0)) == np.argmax(sp_delta.mean(axis=0)), (
-            "Dominant state should agree between narrow σ and δ=0 kernels. "
-            f"sharp mean: {sp_sharp.mean(axis=0)}, delta mean: {sp_delta.mean(axis=0)}"
-        )
-        # Both should find Local dominant on awake behavior.
-        assert np.argmax(sp_delta.mean(axis=0)) == 0, (
-            f"Delta-kernel Local state should dominate; mean probs = {sp_delta.mean(axis=0)}"
-        )
-        # Mean Local probability between narrow-σ and delta differs by less
-        # than 10 percentage points — σ=0.5 is a good approximation of δ.
-        assert abs(sp_sharp[:, 0].mean() - sp_delta[:, 0].mean()) < 0.10, (
-            f"Narrow σ (0.5) Local probability = {sp_sharp[:, 0].mean():.4f} "
-            f"should be close to δ Local probability = {sp_delta[:, 0].mean():.4f}"
-        )
-
     def test_multibin_marginal_log_likelihood_finite_and_negative(self, _sim_data):
         """Marginal log-likelihood is finite and negative across modes.
 
@@ -195,7 +137,7 @@ class TestLocalPositionStdSnapshot:
         finite negative marginal log-likelihood. If mass-balance or
         normalization breaks, this can go positive or become -inf.
         """
-        for sigma in (None, 0.0, 0.5, 5.0):
+        for sigma in (None, 0.5, 5.0):
             detector = NonLocalSortedSpikesDetector(
                 sampling_frequency=_sim_data["sampling_frequency"],
                 local_position_std=sigma,


### PR DESCRIPTION
## Summary

Cleanup of the multi-bin Local state's observation channel and predict-time initial conditions, plus a critical regression fix for Local-vs-Non-Local mass balance discovered during simulated-data verification.

Three load-bearing pieces:
1. **Per-timestep n_bins mass-balance compensation** in the Local kernel (the original PR's "Option B" anchor refactor accidentally removed this and crashed P(Local) → 0 across all σ; restored).
2. **EM-compatible predict-time Local IC override** that copies stored `initial_conditions_` and rewrites only Local rows (preserves EM-updated non-Local blocks bit-exactly).
3. **Validator hardening**: rejects negative, NaN, Inf, and positive σ < `sqrt(np.finfo(np.float32).tiny)` ≈ 1.085e-19 (where σ² would underflow under JAX FTZ).

`local_position_std=None` legacy single-bin Local behavior is unchanged.

## The kernel: anchor with HMM-state mass calibration

For `σ > 0`:
```
raw         = -0.5 * d² / σ²                       # over geodesic distance
log_kernel  = raw - logsumexp(raw) + log(n_bins)   # rescale per timestep
```
giving `exp(log_kernel).sum(axis=1) == n_bins`.

For `σ == 0`: `log(n_bins)` at the animal-snapped bin, `-inf` elsewhere — same row-sum invariant in the delta limit.

The `+ log(n_bins)` is **not density normalization** — it's HMM-state mass calibration: the multi-bin Local state has a uniform `1/n_bins` continuous IC, and without compensation Non-Local dominates by a factor of n_bins regardless of σ.

`σ` is an anchor-width hyperparameter (controls Local's spatial tolerance), not a calibrated measurement-noise scale.

Rows whose interpolated animal position is NaN (tracking dropouts) fall back to a flat kernel (`log_kernel = 0` over all bins).

## Verification on simulated awake-behavior data (seed=0, 97 500 steps)

| σ | main P(Local) | this branch P(Local) | this branch mll |
|---|---|---|---|
| None | 0.713 | 0.713 | −6745.8 |
| 0.0 | (rejected on main) | **0.713** | −6748.3 |
| 0.5 | 0.713 | **0.713** | −6748.3 |
| 5.0 | 0.713 | **0.713** | −6887.3 |

Mean P(Local) recovers to main-like occupancy for comparable σ values; σ=0.0 has no main comparator. Note: the checked-in regression test pins `mean P(Local) > 0.5` per σ, not exact main equivalence — the table values come from a manual smoke run.

## Predict-time Local IC override (EM-compatible)

`compute_local_initial_conditions(position_time, position, time)` returns either
- `None` (legacy `local_position_std is None`, or no Local states), in which case decode falls back to the stored uniform-Local IC, or
- a copy of `self.initial_conditions_` with each Local block's rows zeroed out and a delta scaled by `discrete_initial_conditions[Local]` placed at the bin containing the animal's first interpolated position.

EM updates to non-Local IC blocks are preserved bit-exactly (regression test `test_override_preserves_em_updated_non_local_blocks`). Both `_predict()` and `most_likely_sequence()` route through the shared `_initial_distribution_for_decode` helper. Multi-environment configs with one tracking-dropout Local skip just that state instead of bailing out for the whole helper (per-Local-state NaN handling).

## Behavioral changes vs main

- **Not bit-compatible** with `main` for `local_position_std > 0` and `local_position_std == 0` — the IC at t=0 is now a delta at the animal's bin (was uniform Local mass spread across bins). The σ-sweep occupancy is essentially identical (matches main within numerical noise), but per-frame posteriors differ at t=0.
- **`local_position_std=None`** path is bit-identical to main.
- New regression tests pin both per-σ Local occupancy magnitude (`mean P(Local) > 0.5`) and t=0 override+kernel overlap behavior — failure modes the previous suite was missing.

## Test plan

- [x] All targeted local-state tests pass (`test_local_observation_channel.py`, `test_local_position_std.py`, `test_local_position_std_snapshot.py`, `test_local_spatial_uncertainty.py`)
- [x] Lint + format clean (`ruff check`, `ruff format --check`)
- [x] Manual simulated-data smoke check confirms P(Local) recovery across σ ∈ {None, 0.0, 0.5, 2.0, 5.0, 20.0}; checked-in test pins `mean P(Local) > 0.5` for σ ∈ {0.0, 0.5, 5.0}
- [x] EM (`estimate_parameters`) path runs and invokes the IC override (`test_estimate_parameters_runs_with_local_position_std`); manual smoke separately confirmed `estimate_parameters` with `estimate_initial_conditions=True` runs to completion and post-EM `initial_conditions_` sums to 1
- [x] Clusterless (`NonLocalClusterlessDetector`) fit + predict completes; state probabilities sum to 1
- [x] σ²-underflow guard rejects 1e-19 and 1e-50 (regression test)
- [x] IC override preserves EM-updated non-Local blocks; NaN t=0 handling is per-Local-state (regression test)
- [x] Multi-arm `track_graph` with gap bins: override length matches `state_ind_`, delta lands on correct arm, gap bins exactly 0

## Migration notes

- **σ semantics**: Treat `local_position_std` as an anchor-width / spatial-tolerance hyperparameter, not a calibrated measurement-noise standard deviation.
- **First-frame Local override**: For the predict-time Local delta override to apply, the first decode row's interpolated animal position must be non-NaN. If NaN for a given Local state, that state's block falls back to the stored IC and a warning is logged — decoding still runs.
- **NaN rows in the kernel**: Rows whose interpolated animal position is NaN fall back to a flat kernel (`log_kernel = 0` over all bins), giving the forward step no spatial information from this channel for those rows.
- **t=0 overlap**: At t=0 the IC override has already concentrated Local mass at the animal's bin, and the kernel's `+ log(n_bins)` compensation also boosts that same bin. The overlap sharpens but does not break the t=0 distribution; for typical decoding windows it is negligible. For very short sequences or tight marginal-likelihood comparisons, callers should be aware of it.
- **σ ≈ 0 footgun**: Positive σ values that would make `σ²` underflow in float32 (≈ < 1.085e-19) are rejected at construction. Use `0.0` explicitly for the delta kernel.

## Files changed

- `src/non_local_detector/models/base.py` — kernel + IC override + helpers + docstrings (+~480 / −110)
- `src/non_local_detector/models/non_local_model.py` — public docstring (+10 / −5)
- `src/non_local_detector/tests/models/test_local_observation_channel.py` — new file, 700+ lines covering validator, kernels, IC override, EM, Viterbi, clusterless, occupancy regression, t=0 overlap
- `src/non_local_detector/tests/models/test_local_position_std.py` — kernel-shape tests updated for n_bins mass-balance contract
- `src/non_local_detector/tests/models/test_local_position_std_snapshot.py` — pinned σ ∈ {None, 0.0, 0.5, 5.0} produce finite mll
- `src/non_local_detector/tests/integration/test_local_spatial_uncertainty.py` — restored σ=0 fit/predict integration test

## Commit history (chronological)

1. `4a8b867` Initial Local state observation-channel cleanup
2. `b89aa24` Fix Local IC override shape on linearized multi-arm tracks
3. `4e780d6` Refresh docstrings; harden validator + kernel NaN handling
4. `0faf93c` Strengthen override tests; add EM and clusterless coverage
5. `169a779` Loud asserts (no silent-zero gates)
6. `989aff6` Dedup IC loop; factor NaN-safe distance helper
7. `93e97f1` Restore `local_position_std=0.0` as valid delta-kernel mode
8. `ea0746a` Make Gaussian normalizer dimension-aware (later superseded)
9. `84e2868` Doc kernel as radial likelihood
10. `fcb4d22` Apply IC override in `most_likely_sequence`
11. `44a7e14` Factor shared helpers
12. `873da39` Switch to anchor-only kernel ("Option B") + EM-compatible IC override
13. `bf733ab` Soften stale Gaussian-density wording
14. `0f2dd75` Reject `local_position_std` that underflows to 0 in float32
15. `35c2ae9` Tighten guard to cover σ² underflow (sqrt(float32 tiny))
16. `7db57d7` **Restore n_bins mass-balance compensation** (the regression fix)
17. `3a5c52b` Refresh stale docs; pin t=0 override+kernel overlap behavior
18. `415f51f` Tighten NaN-handling wording in kernel docstrings/comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)