### PR TITLE
Avoid materializing the joint covariate transition tensor

### DIFF
--- a/src/non_local_detector/core.py
+++ b/src/non_local_detector/core.py
@@ -584,10 +584,29 @@ def most_likely_sequence(
 
 
 ## Covariate dependent filtering and smoothing ##
+def _index_discrete_transition(
+    discrete_transition_matrix_t: ArrayLike,
+    state_ind: ArrayLike,
+) -> jnp.ndarray:
+    """Expand a discrete transition to the joint state-bin space.
+
+    Parameters
+    ----------
+    discrete_transition_matrix_t : jnp.ndarray, shape (n_states, n_states)
+    state_ind : jnp.ndarray, shape (n_state_bins,)
+        Maps each state bin to its discrete state.
+
+    Returns
+    -------
+    discrete_indexed : jnp.ndarray, shape (n_state_bins, n_state_bins)
+    """
+    return discrete_transition_matrix_t[jnp.ix_(state_ind, state_ind)]
+
+
 def _get_transition_matrix(
     discrete_transition_matrix_t: ArrayLike,
     continuous_transition_matrix: ArrayLike,
-    state_ind: ArrayLike | None = None,
+    state_ind: ArrayLike,
 ) -> jnp.ndarray:
     """Get the transition matrix for the current time point.
 
@@ -595,25 +614,18 @@ def _get_transition_matrix(
 
     Parameters
     ----------
-    discrete_transition_matrix_t : jnp.ndarray, shape (n_state_bins, n_state_bins) or (n_states, n_states)
-        If state_ind is provided, expected shape is (n_states, n_states) and will be indexed.
-        If state_ind is None, expected shape is (n_state_bins, n_state_bins) (pre-indexed).
+    discrete_transition_matrix_t : jnp.ndarray, shape (n_states, n_states)
     continuous_transition_matrix : jnp.ndarray, shape (n_state_bins, n_state_bins)
-    state_ind : jnp.ndarray, shape (n_state_bins,), optional
-        If provided, used to index discrete_transition_matrix_t.
-        If None, assumes discrete_transition_matrix_t is already indexed.
+    state_ind : jnp.ndarray, shape (n_state_bins,)
+        Maps each state bin to its discrete state.
 
     Returns
     -------
     transition_matrix : jnp.ndarray, shape (n_state_bins, n_state_bins)
     """
-    if state_ind is not None:
-        # Index (n_states, n_states) up to (n_state_bins, n_state_bins).
-        discrete_indexed = discrete_transition_matrix_t[jnp.ix_(state_ind, state_ind)]
-    else:
-        # Already a (n_state_bins, n_state_bins) matrix.
-        discrete_indexed = discrete_transition_matrix_t
-
+    discrete_indexed = _index_discrete_transition(
+        discrete_transition_matrix_t, state_ind
+    )
     return continuous_transition_matrix * discrete_indexed
 
 
@@ -681,7 +693,7 @@ _filter_covariate_dependent_internal = jax.jit(
 def smoother_covariate_dependent(
     discrete_transition_matrix: ArrayLike,
     continuous_transition_matrix: ArrayLike,
-    state_ind: ArrayLike | None,
+    state_ind: ArrayLike,
     filtered_probs: ArrayLike,
     initial: ArrayLike | None = None,
     ind: ArrayLike | None = None,
@@ -691,10 +703,10 @@ def smoother_covariate_dependent(
 
     Parameters
     ----------
-    discrete_transition_matrix : jnp.ndarray, shape (n_time, n_states, n_states) or (n_time, n_state_bins, n_state_bins)
+    discrete_transition_matrix : jnp.ndarray, shape (n_time, n_states, n_states)
     continuous_transition_matrix : jnp.ndarray, shape (n_state_bins, n_state_bins)
-    state_ind : jnp.ndarray, shape (n_state_bins,), optional
-        If None, discrete_transition_matrix is assumed pre-indexed
+    state_ind : jnp.ndarray, shape (n_state_bins,)
+        Maps each state bin to its discrete state.
     filtered_probs : jnp.ndarray, shape (n_time, n_state_bins)
     initial : jnp.ndarray, shape (n_state_bins,), optional
     ind : jnp.ndarray, shape (n_time,), optional
@@ -1020,7 +1032,9 @@ def viterbi_covariate_dependent(
     def _backward_pass(best_next_score, args):
         t, discrete_transition_matrix_t = args
         # Index states and compute log per-step (avoids T×N×N materialization)
-        discrete_t_indexed = discrete_transition_matrix_t[jnp.ix_(state_ind, state_ind)]
+        discrete_t_indexed = _index_discrete_transition(
+            discrete_transition_matrix_t, state_ind
+        )
         log_discrete_t = _safe_log(discrete_t_indexed)
 
         # Build log-space transition matrix: log(A * B) = log(A) + log(B)

--- a/src/non_local_detector/core.py
+++ b/src/non_local_detector/core.py
@@ -608,10 +608,11 @@ def _get_transition_matrix(
     transition_matrix : jnp.ndarray, shape (n_state_bins, n_state_bins)
     """
     if state_ind is not None:
-        # Need to index - used by public API functions
+        # Index (n_states, n_states) -> (n_state_bins, n_state_bins) per step.
+        # Used by the public API and the chunked covariate-dependent driver.
         discrete_indexed = discrete_transition_matrix_t[jnp.ix_(state_ind, state_ind)]
     else:
-        # Already indexed - used by optimized chunked functions
+        # Caller passed an already-indexed (n_state_bins, n_state_bins) matrix.
         discrete_indexed = discrete_transition_matrix_t
 
     return continuous_transition_matrix * discrete_indexed
@@ -786,7 +787,11 @@ def chunked_filter_smoother_covariate_dependent(
     log_likelihood_args : tuple
     is_missing : np.ndarray, shape (n_time,), optional
     n_chunks : int, optional
-        Number of chunks to split the data into, by default 1
+        Number of chunks to split the data into, by default 1.
+        The discrete transition is expanded to the joint
+        (n_state_bins, n_state_bins) transition one time step at a time inside
+        the scan, so the (n_time, n_state_bins, n_state_bins) joint transition
+        is never materialized; ``n_chunks=1`` is feasible even on long sessions.
     log_likelihoods : np.ndarray, optional
     cache_log_likelihoods : bool, optional
         If True, log likelihoods are cached instead of recomputed for each chunk, by default True
@@ -889,12 +894,13 @@ def chunked_filter_smoother_covariate_dependent(
                 "log_likelihoods", log_likelihood_chunk
             )
 
-        # Chunk discrete transitions: index time first, then states
-        # This avoids materializing the full T×N×N array (important for large T)
+        # Chunk discrete transitions by time only, keeping shape
+        # (chunk, n_states, n_states). The scan body indexes states per step,
+        # so the full (chunk, n_state_bins, n_state_bins) joint transition is
+        # never materialized (it would be ~T×n_B² and dominate memory).
         dtm_chunk = discrete_transition_matrix_jax[time_inds]
-        dtm_chunk_indexed = dtm_chunk[:, state_ind_jax[:, None], state_ind_jax]
 
-        # Donated: log_likelihood_chunk, dtm_chunk_indexed, initial_distribution
+        # Donated: log_likelihood_chunk, dtm_chunk, initial_distribution
         # All are single-use per iteration - safe to donate
         # Note: Small arrays may trigger benign donation warnings in tests
         (
@@ -904,9 +910,9 @@ def chunked_filter_smoother_covariate_dependent(
             initial_distribution=(
                 initial_distribution_jax if chunk_id == 0 else predicted_probs_next
             ),
-            discrete_transition_matrix=dtm_chunk_indexed,
+            discrete_transition_matrix=dtm_chunk,
             continuous_transition_matrix=continuous_transition_matrix_jax,
-            state_ind=None,  # Already indexed, don't index again
+            state_ind=state_ind_jax,  # Index states per step inside the scan
             log_likelihoods=log_likelihood_chunk,
         )
 
@@ -933,17 +939,17 @@ def chunked_filter_smoother_covariate_dependent(
     for chunk_id, time_inds_np in enumerate(reversed(time_chunks)):
         time_inds = jnp.asarray(time_inds_np)
 
-        # Chunk discrete transitions for backward pass too
+        # Chunk discrete transitions for backward pass too; keep shape
+        # (chunk, n_states, n_states) and index states per step in the scan.
         dtm_chunk = discrete_transition_matrix_jax[time_inds_np]
-        dtm_chunk_indexed = dtm_chunk[:, state_ind_jax[:, None], state_ind_jax]
 
-        # Donated: dtm_chunk_indexed, filtered_probs slice, initial boundary
+        # Donated: dtm_chunk, filtered_probs slice, initial boundary
         # All are single-use per iteration
         # Note: Small arrays may trigger benign donation warnings in tests
         acausal_posterior_chunk = _smoother_covariate_dependent_internal(
-            discrete_transition_matrix=dtm_chunk_indexed,
+            discrete_transition_matrix=dtm_chunk,
             continuous_transition_matrix=continuous_transition_matrix_jax,
-            state_ind=None,  # Already indexed
+            state_ind=state_ind_jax,  # Index states per step inside the scan
             filtered_probs=causal_posterior_jax[time_inds],
             initial=(
                 causal_posterior_jax[-1]

--- a/src/non_local_detector/core.py
+++ b/src/non_local_detector/core.py
@@ -608,11 +608,10 @@ def _get_transition_matrix(
     transition_matrix : jnp.ndarray, shape (n_state_bins, n_state_bins)
     """
     if state_ind is not None:
-        # Index (n_states, n_states) -> (n_state_bins, n_state_bins) per step.
-        # Used by the public API and the chunked covariate-dependent driver.
+        # Index (n_states, n_states) up to (n_state_bins, n_state_bins).
         discrete_indexed = discrete_transition_matrix_t[jnp.ix_(state_ind, state_ind)]
     else:
-        # Caller passed an already-indexed (n_state_bins, n_state_bins) matrix.
+        # Already a (n_state_bins, n_state_bins) matrix.
         discrete_indexed = discrete_transition_matrix_t
 
     return continuous_transition_matrix * discrete_indexed
@@ -894,10 +893,8 @@ def chunked_filter_smoother_covariate_dependent(
                 "log_likelihoods", log_likelihood_chunk
             )
 
-        # Chunk discrete transitions by time only, keeping shape
-        # (chunk, n_states, n_states). The scan body indexes states per step,
-        # so the full (chunk, n_state_bins, n_state_bins) joint transition is
-        # never materialized (it would be ~T×n_B² and dominate memory).
+        # Time-slice only: the scan body indexes states per step, so the joint
+        # (chunk, n_state_bins, n_state_bins) transition is never materialized.
         dtm_chunk = discrete_transition_matrix_jax[time_inds]
 
         # Donated: log_likelihood_chunk, dtm_chunk, initial_distribution
@@ -912,7 +909,7 @@ def chunked_filter_smoother_covariate_dependent(
             ),
             discrete_transition_matrix=dtm_chunk,
             continuous_transition_matrix=continuous_transition_matrix_jax,
-            state_ind=state_ind_jax,  # Index states per step inside the scan
+            state_ind=state_ind_jax,
             log_likelihoods=log_likelihood_chunk,
         )
 
@@ -939,9 +936,8 @@ def chunked_filter_smoother_covariate_dependent(
     for chunk_id, time_inds_np in enumerate(reversed(time_chunks)):
         time_inds = jnp.asarray(time_inds_np)
 
-        # Chunk discrete transitions for backward pass too; keep shape
-        # (chunk, n_states, n_states) and index states per step in the scan.
-        dtm_chunk = discrete_transition_matrix_jax[time_inds_np]
+        # Time-slice only; states indexed per step in the scan (see forward).
+        dtm_chunk = discrete_transition_matrix_jax[time_inds]
 
         # Donated: dtm_chunk, filtered_probs slice, initial boundary
         # All are single-use per iteration
@@ -949,7 +945,7 @@ def chunked_filter_smoother_covariate_dependent(
         acausal_posterior_chunk = _smoother_covariate_dependent_internal(
             discrete_transition_matrix=dtm_chunk,
             continuous_transition_matrix=continuous_transition_matrix_jax,
-            state_ind=state_ind_jax,  # Index states per step inside the scan
+            state_ind=state_ind_jax,
             filtered_probs=causal_posterior_jax[time_inds],
             initial=(
                 causal_posterior_jax[-1]


### PR DESCRIPTION
## Problem

`chunked_filter_smoother_covariate_dependent` pre-indexed the per-time discrete transition into the full `(chunk, n_state_bins, n_state_bins)` joint transition before calling the filter/smoother:

```python
dtm_chunk_indexed = dtm_chunk[:, state_ind_jax[:, None], state_ind_jax]
```

At `n_chunks=1` on a 1-hour session (`n_time ≈ 7×10⁵`, `n_B = 745`) that tensor is **~1.5 TB**, forcing users to split the covariate-dependent path into many chunks (which adds inter-chunk syncs, host↔device transfers, and breaks the JIT cache when chunk sizes vary).

## Fix

The filter/smoother scan bodies already index the discrete transition per step via `_get_transition_matrix` — the same path the public non-chunked `filter_covariate_dependent` uses. The driver now passes the **unindexed** `(chunk, n_states, n_states)` chunk plus `state_ind` instead of the pre-indexed tensor + `state_ind=None`.

The full `(n_time, n_B, n_B)` joint transition is never materialized; only a per-step `(n_B, n_B)` transient remains (reused each scan iteration, ~2 MB). `jax.make_jaxpr` confirms the `(T, n_B, n_B)` shape no longer appears.

20 insertions / 14 deletions, all in `core.py`.

## Correctness

Verified numerically equivalent (GPU and CPU):

- **Bit-identical** (`0.00e+00`, float32 and float64) to the unmodified public non-chunked `filter_covariate_dependent` / `smoother_covariate_dependent` — the chunked path now routes through the same compiled code path, so internal consistency actually improves.
- Matches the pre-change output to ≤`6e-14` on the marginal log-likelihood (XLA sum reassociation), ≤`6e-16` on all posteriors.
- Tests pass: 16 covariate/chunked-parity, 72 core, 51 transition-estimation, 3 EM-monotonicity. Ruff clean.

## Memory & speed (A100 80 GB, single chunk)

| Workload | Before | After |
|---|---|---|
| `n_time=10,000` | OOM (44.5 GB peak, then fails) | OK — 0.18 GB peak, 0.6 s |
| `n_time=700,000` (~1 hr) | OOM (1.41 TiB requested) | OK — **10.6 GB peak**, ~38 s/run |
| `n_time=700,000`, `n_chunks=100` | OOM (33 GB peak, then fails) | — |

The covariate-dependent path could not run single-chunk at any realistic size before; it now handles a full 1-hour session in ~10.6 GB (would fit a 16 GB GPU). CPU: ~1.85× faster on a workload both versions can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)