### PR TITLE
Derive frozen-rows transition mask lazily so it stays out of vars()/get_params()

### DIFF
--- a/src/non_local_detector/models/base.py
+++ b/src/non_local_detector/models/base.py
@@ -370,13 +370,17 @@ class _DetectorBase(BaseEstimator, abc.ABC):
         self.discrete_transition_regularization = discrete_transition_regularization
         self.discrete_transition_type = discrete_transition_type
         self.discrete_transition_prior_weight = discrete_transition_prior_weight
-        # Normalize and validate frozen rows against n_states up front
         self.frozen_discrete_transition_rows = frozen_discrete_transition_rows
-        self._frozen_discrete_transition_rows_mask_ = (
-            _normalize_frozen_discrete_transition_rows(
-                frozen_discrete_transition_rows,
-                n_states=len(discrete_initial_conditions),
-            )
+        # Validate the frozen-row spec against n_states up front (raises on bad
+        # input). The normalized boolean mask itself is derived lazily via the
+        # ``_frozen_discrete_transition_rows_mask_`` property rather than stored
+        # as an instance attribute, so it stays out of ``vars()`` /
+        # ``get_params()`` and does not break serialization round-trips that
+        # reconstruct the model from its public parameters (e.g. Spyglass's
+        # DecodingParameters).
+        _normalize_frozen_discrete_transition_rows(
+            frozen_discrete_transition_rows,
+            n_states=len(discrete_initial_conditions),
         )
 
         # Continuous state transition parameters
@@ -413,6 +417,27 @@ class _DetectorBase(BaseEstimator, abc.ABC):
                 ),
             )
         self.local_position_std = local_position_std
+
+    @property
+    def _frozen_discrete_transition_rows_mask_(self) -> np.ndarray | None:
+        """Boolean mask of frozen discrete-transition rows (derived, lazy).
+
+        Recomputed from ``frozen_discrete_transition_rows`` on each access
+        rather than stored as an instance attribute, so it does not appear in
+        ``vars()`` / ``get_params()``. This keeps serialization round-trips that
+        reconstruct the model from its public parameters (e.g. Spyglass's
+        ``DecodingParameters``) from passing this derived attribute back into
+        ``__init__`` as an unexpected keyword argument.
+
+        Returns
+        -------
+        np.ndarray of bool, shape (n_states,), or None
+            ``None`` when no rows are frozen.
+        """
+        return _normalize_frozen_discrete_transition_rows(
+            self.frozen_discrete_transition_rows,
+            n_states=len(self.discrete_initial_conditions),
+        )
 
     def _validate_position_dimensionality(
         self, position: np.ndarray, context: str = "fit"

--- a/src/non_local_detector/tests/models/test_frozen_transition_rows.py
+++ b/src/non_local_detector/tests/models/test_frozen_transition_rows.py
@@ -128,6 +128,59 @@ class TestDetectorConstructorPlumbing:
             NonLocalSortedSpikesDetector(frozen_discrete_transition_rows=[7])
 
 
+@pytest.mark.unit
+class TestFrozenMaskNotSerialized:
+    """The derived row mask must stay out of ``vars()`` / ``get_params()``.
+
+    It is computed lazily via a property, so serialization round-trips that
+    rebuild a model from its public parameters (e.g. Spyglass's
+    ``DecodingParameters``, which stores ``vars(model)`` and reconstructs with
+    ``Detector(**params)``) do not pass the derived attribute back into
+    ``__init__`` as an unexpected keyword argument.
+    """
+
+    @pytest.mark.parametrize(
+        "make",
+        [
+            NonLocalSortedSpikesDetector,
+            NonLocalClusterlessDetector,
+            ContFragSortedSpikesClassifier,
+        ],
+    )
+    def test_mask_absent_from_vars_and_get_params(self, make):
+        model = make()
+        assert "_frozen_discrete_transition_rows_mask_" not in vars(model)
+        assert "_frozen_discrete_transition_rows_mask_" not in model.get_params(
+            deep=False
+        )
+
+    def test_property_still_returns_correct_mask(self):
+        # Default NonLocal model freezes the No-Spike row (index 1 of 4 states).
+        model = NonLocalSortedSpikesDetector()
+        np.testing.assert_array_equal(
+            model._frozen_discrete_transition_rows_mask_,
+            [False, True, False, False],
+        )
+        # Opt-out still yields None.
+        assert (
+            NonLocalSortedSpikesDetector(
+                frozen_discrete_transition_rows=None
+            )._frozen_discrete_transition_rows_mask_
+            is None
+        )
+
+    def test_vars_roundtrip_reconstructs_via_base_detector(self):
+        """A ContFrag model's ``vars()`` must reconstruct through the base
+        detector (the Spyglass pattern) now that the mask no longer leaks.
+        """
+        from non_local_detector.models.base import SortedSpikesDetector
+
+        model = ContFragSortedSpikesClassifier()
+        # Previously raised: unexpected kwarg _frozen_discrete_transition_rows_mask_
+        rebuilt = SortedSpikesDetector(**vars(model))
+        assert isinstance(rebuilt, SortedSpikesDetector)
+
+
 @pytest.mark.integration
 @pytest.mark.slow
 class TestFrozenRowEndToEnd:


### PR DESCRIPTION
## Problem

`_DetectorBase.__init__` stores `_frozen_discrete_transition_rows_mask_` -- a
boolean row mask derived from the `frozen_discrete_transition_rows` constructor
argument -- as an instance attribute. Because it is a normal instance attribute,
it appears in both `vars(model)` and `get_params()`, even though it is not a
constructor parameter.

This breaks serialization round-trips that reconstruct a model from its
attributes. For example, Spyglass's `DecodingParameters` stores `vars(model)`
and later reconstructs the model with `Detector(**params)`; the derived mask is
passed back into `__init__` and raises:

```
TypeError: __init__() got an unexpected keyword argument '_frozen_discrete_transition_rows_mask_'
```

Any consumer that treats a model's public attributes as its constructor
parameters hits the same problem, and it will recur whenever a new derived
attribute is added in `__init__`.

## Solution

Compute the mask lazily via a read-only `_frozen_discrete_transition_rows_mask_`
property (recomputed from `frozen_discrete_transition_rows` and the state count
on access) instead of storing it as an instance attribute in `__init__`. The
up-front validation of `frozen_discrete_transition_rows` against `n_states` is
kept, so invalid input still raises at construction time. The derived value is
unchanged; it simply no longer appears in `vars()` / `get_params()`.

## Validation

- Existing constructor-plumbing and slow end-to-end EM frozen-row tests pass
  unchanged (behavior preserved, including byte-exact frozen rows after EM).
- New tests assert the mask is absent from `vars()` and `get_params()` for the
  default models, that the property still returns the correct mask (and `None`
  when no rows are frozen), and that a ContFrag model's `vars()` now
  reconstructs through the base detector.
- `ruff check` / `ruff format` clean.

## Risks / possible issues

- The mask is recomputed on each access rather than cached. It is read only a
  handful of times per fit/predict (discrete transition-matrix construction) and
  `_normalize_frozen_discrete_transition_rows` is inexpensive, so there is no
  meaningful performance impact; it is not on a per-timestep hot path.
- Validation timing is unchanged: invalid `frozen_discrete_transition_rows` is
  still rejected at construction.
- This change alone fixes `vars()`/`get_params()`-based consumers for the base
  and ContFrag models. The `NonLocal*` models additionally expose subclass-only
  parameters (`non_local_position_penalty`, `non_local_penalty_std`); a paired
  Spyglass change reconstructs via the concrete model class so those round-trip
  as well. The two changes are independently beneficial.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
